### PR TITLE
Feat coses with connection

### DIFF
--- a/projects/memapCore/src/main/java/memap/components/ClientCoupler.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientCoupler.java
@@ -158,6 +158,8 @@ public class ClientCoupler extends Coupler {
 		couplerMessage.secondaryNetwork = secondaryNetwork;
 		couplerMessage.operationalCostEUR = opCost;
 		couplerMessage.varOperationalCostEUR = Stream.of(opCostFC).mapToDouble(Double::doubleValue).toArray();
+		// System.out.println("varopCosts-Length = " + couplerMessage.varOperationalCostEUR.length);
+		// TODO: once experienced strange bug for cm.varOperationalCostEUR: "Index 4 out of bounds for length 4", although mpc was 5?! 
 		couplerMessage.operationalCostCO2 = costCO2;
 		couplerMessage.efficiencyElec = efficiencyElec;
 		couplerMessage.efficiencyHeat = efficiencyHeat;

--- a/projects/memapCore/src/main/java/memap/components/ClientCoupler.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientCoupler.java
@@ -174,7 +174,11 @@ public class ClientCoupler extends Coupler {
 		if (requestContentReceived instanceof OptimizationResultMessage) {
 			OptimizationResultMessage optResult = ((OptimizationResultMessage) requestContentReceived);
 			for (String key : optResult.resultMap.keySet()) {
-				if (key.equals(actorName)) {
+				if ( // write setpoint only for primary Network 
+					(this.primaryNetwork == NetworkType.HEAT && key.equals(actorName + "_withEffieciency_HEAT")) || 
+					(this.primaryNetwork == NetworkType.ELECTRICITY && key.equals(actorName + "_withEffieciency_ELECTRICITY")) 
+					) 
+				{
 					optimizationAdvice = optResult.resultMap.get(key);
 					
 					// Write scalar setpoint to EMS (single value)

--- a/projects/memapCore/src/main/java/memap/components/ClientDemand.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientDemand.java
@@ -302,7 +302,7 @@ public class ClientDemand extends Consumer implements CurrentTimeStepSubscriber 
 		if (requestContentReceived instanceof OptimizationResultMessage) {
 			OptimizationResultMessage optResult = ((OptimizationResultMessage) requestContentReceived);
 			for (String key : optResult.resultMap.keySet()) {
-				if (key.equals("ElecBuy")) {
+				if ((key.equals("ElecBuy")) && (this.networkType == NetworkType.ELECTRICITY)) {
 					optimizationAdviceBuy = optResult.resultMap.get(key);
 					DataValue singlevalueBuySetpoint = new DataValue(new Variant(optimizationAdviceBuy[0]), null, null);
 					client.writeValue(setpointGridBuyId, singlevalueBuySetpoint);
@@ -315,7 +315,7 @@ public class ClientDemand extends Consumer implements CurrentTimeStepSubscriber 
 						e.printStackTrace();
 					}		
 				}
-				if (key.equals("ElecSell")) {
+				if ((key.equals("ElecSell")) && (this.networkType == NetworkType.ELECTRICITY)) {
 					optimizationAdviceSell = optResult.resultMap.get(key);
 					DataValue singlevalueSellSetpoint = new DataValue(new Variant(optimizationAdviceSell[0]), null, null);
 					client.writeValue(setpointGridSellId, singlevalueSellSetpoint);

--- a/projects/memapCore/src/main/java/memap/components/ClientDemand.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientDemand.java
@@ -51,6 +51,8 @@ public class ClientDemand extends Consumer implements CurrentTimeStepSubscriber 
 	
 	public double[] optimizationAdviceBuy;
 	public double[] optimizationAdviceSell;
+	public double[] optAdviceHeatPurchase; //from whom?
+	public double[] optAdviceHeatDelivery; //to whom?
 
 	public List<UaMonitoredItem> itemsDemand;
 
@@ -327,6 +329,11 @@ public class ClientDemand extends Consumer implements CurrentTimeStepSubscriber 
 					} catch (InterruptedException | ExecutionException e) {
 						e.printStackTrace();
 					}
+				}
+				if ((key.equals("connection_FromCoSES_H1_ToCoSES_H2Frwd")) && (this.networkType == NetworkType.HEAT)) {
+					optAdviceHeatPurchase = optResult.resultMap.get(key);
+					// Write heat transfer setpoint here
+					System.out.println("HEAT Transfer between buildings (setpoint): " + optAdviceHeatPurchase[0]);
 				}
 			}
 		}

--- a/projects/memapCore/src/main/java/memap/components/ClientEMS.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientEMS.java
@@ -6,9 +6,9 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 
-import akka.basicMessages.AnswerContent;
-import memap.components.prototypes.Device;
+import memap.components.prototypes.Connection;
 import memap.controller.TopologyController;
+import memap.helper.configurationOptions.Optimizer;
 import memap.helperOPCua.BasicClient;
 import memap.messages.extension.NetworkType;
 import memap.messages.planning.ConnectionMessage;
@@ -21,7 +21,7 @@ import memap.messages.planning.ConnectionMessage;
  * @param port
  */
 
-public class ClientEMS extends Device {
+public class ClientEMS extends Connection {
 	
 	/** Reference to the topology */
 	protected TopologyController topologyController;
@@ -31,34 +31,37 @@ public class ClientEMS extends Device {
 	public BasicClient client;
 	public NodeId triggerId;
 	public NodeId connEffId;
-	public double connEff;
 	public double trigger;
 	
-	public ClientEMS(BasicClient client, String name, NodeId triggerId, NodeId connEffId, int port) throws InterruptedException, ExecutionException {
-		super(name, port);
+	public ClientEMS(BasicClient client, TopologyController topologyController, String name, NodeId triggerId, NodeId connEffId, int port) throws InterruptedException, ExecutionException {
+		// How to get the Stings names of connected buildings? From connection Matrix:
+		super("CoSES_H1", "CoSES_H2", 50, client.readFinalDoubleValue(connEffId), 999);
 		this.client = client;
-		this.triggerId = triggerId;
-		this.connEff = client.readFinalDoubleValue(connEffId);
+		this.topologyController = topologyController;
+		this.triggerId = triggerId; 
 	}
 
 	@Override
 	public void makeDecision() {
-//		if (topologyController.getOptimizer() == Optimizer.MILPwithConnections) {
-		connectionMessage.id = fullActorPath;
-		connectionMessage.name = actorName;
-//		connectionMessage.efficiency = connEff;
-		connectionMessage.efficiency = 0.0001;
-		// How to get the Stings names of connected buildings? From connection Matrix
-//		connectionMessage.connectedBuildingFrom = "CoSES_H1";
-//		connectionMessage.connectedBuildingTo = "unknown";
-		connectionMessage.pipeLengthInMeter = 50;
-		connectionMessage.operationalCostEUR = 0.0001;
-		connectionMessage.operationalCostCO2 = 0.0001;
-		connectionMessage.networkType = NetworkType.HEAT;
-//		}
+		if (topologyController.getOptimizer() == Optimizer.MILPwithConnections) {
+			
+			connectionMessage.networkType = NetworkType.HEAT;
+			connectionMessage.name = actorName;
+			connectionMessage.id = fullActorPath;
+		
+			connectionMessage.connectedBuildingFrom = fullActorPath.split("/")[this.fullActorPath.split("/").length-2];		
+			connectionMessage.connectedBuildingTo = connectedBuilding;
+			
+			connectionMessage.efficiency = efficiency;
+			connectionMessage.maxPower = q_max;
+			connectionMessage.pipeLengthInMeter = pipeLengthInMeter;
+			connectionMessage.operationalCostEUR = 0.0001;
+			connectionMessage.operationalCostCO2 = 0.0001;
+		
+		}
 	}
 
-
+	@Override
 	public void handleRequest() {
 		
 		if (triggerId != null) {
@@ -77,14 +80,6 @@ public class ClientEMS extends Device {
 			System.out.println("Trigger written: " + trigger);
 
 		}
-	}
-
-
-
-	@Override
-	public AnswerContent returnAnswerContentToSend() {
-		// TODO Auto-generated method stub
-		return null;
 	}
 
 }

--- a/projects/memapCore/src/main/java/memap/components/ClientEMS.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientEMS.java
@@ -54,7 +54,8 @@ public class ClientEMS extends Connection {
 			connectionMessage.connectedBuildingTo = connectedBuilding;
 			
 			connectionMessage.efficiency = efficiency;
-			connectionMessage.maxPower = q_max;
+			connectionMessage.maxPower = 0.0; //q_max;
+			// TODO: efficiency = 0 seems to not prevent heat transfer
 			connectionMessage.pipeLengthInMeter = pipeLengthInMeter;
 			connectionMessage.operationalCostEUR = 0.0001;
 			connectionMessage.operationalCostCO2 = 0.0001;

--- a/projects/memapCore/src/main/java/memap/components/ClientEMS.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientEMS.java
@@ -8,7 +8,10 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 
 import akka.basicMessages.AnswerContent;
 import memap.components.prototypes.Device;
+import memap.controller.TopologyController;
 import memap.helperOPCua.BasicClient;
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.ConnectionMessage;
 
 
 /**
@@ -20,19 +23,40 @@ import memap.helperOPCua.BasicClient;
 
 public class ClientEMS extends Device {
 	
+	/** Reference to the topology */
+	protected TopologyController topologyController;
+	
+	public ConnectionMessage connectionMessage = new ConnectionMessage();
+	
 	public BasicClient client;
 	public NodeId triggerId;
-	double trigger;
+	public NodeId connEffId;
+	public double connEff;
+	public double trigger;
 	
-	public ClientEMS(BasicClient client, String name, NodeId triggerId, int port) {
+	public ClientEMS(BasicClient client, String name, NodeId triggerId, NodeId connEffId, int port) throws InterruptedException, ExecutionException {
 		super(name, port);
 		this.client = client;
 		this.triggerId = triggerId;
-		
-		
-		
+		this.connEff = client.readFinalDoubleValue(connEffId);
 	}
 
+	@Override
+	public void makeDecision() {
+//		if (topologyController.getOptimizer() == Optimizer.MILPwithConnections) {
+		connectionMessage.id = fullActorPath;
+		connectionMessage.name = actorName;
+//		connectionMessage.efficiency = connEff;
+		connectionMessage.efficiency = 0.0001;
+		// How to get the Stings names of connected buildings? From connection Matrix
+//		connectionMessage.connectedBuildingFrom = "CoSES_H1";
+//		connectionMessage.connectedBuildingTo = "unknown";
+		connectionMessage.pipeLengthInMeter = 50;
+		connectionMessage.operationalCostEUR = 0.0001;
+		connectionMessage.operationalCostCO2 = 0.0001;
+		connectionMessage.networkType = NetworkType.HEAT;
+//		}
+	}
 
 
 	public void handleRequest() {

--- a/projects/memapCore/src/main/java/memap/components/ClientProducer.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientProducer.java
@@ -169,7 +169,7 @@ public class ClientProducer extends Producer {
 			
 			OptimizationResultMessage optResult = ((OptimizationResultMessage) requestContentReceived);
 			for (String key : optResult.resultMap.keySet()) {
-				if (key.equals(actorName)) {
+				if (key.equals(actorName + "_withEfficiency")) {
 					optimizationAdvice = optResult.resultMap.get(key);
 					
 					// Write scalar setpoint to EMS (single value)

--- a/projects/memapCore/src/main/java/memap/components/ClientStorage.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientStorage.java
@@ -88,10 +88,8 @@ public class ClientStorage extends Storage {
 		this.outputSetpointId = outputSetpointId;
 		this.outputSetpointsId = outputSetpointsId;
 		this.networkType = setNetworkType(client, nodeIdSector);
-//		this.opCost = client.readFinalDoubleValue(opCostId);
-//		this.costCO2 = client.readFinalDoubleValue(costCO2Id);
-		this.opCost = 0.0;
-		this.costCO2 = 0.0;
+		this.opCost = client.readFinalDoubleValue(opCostId);
+		this.costCO2 = client.readFinalDoubleValue(costCO2Id);
 		this.calculatedSocId = calculatedSocId;
 		
 //		System.out.println("Initial SOC = " + this.stateOfCharge);

--- a/projects/memapCore/src/main/java/memap/components/ClientStorage.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientStorage.java
@@ -199,7 +199,7 @@ public class ClientStorage extends Storage {
 			// Alphas and betas have to be calculated here as well. 
 			// helper parameters, only depend on time step length and storage parameters
 			double alpha = 1 - standbyLosses * delta_time;
-			double beta_to = delta_time/ this.capacity * this.effIN;
+			double beta_to = (delta_time/ this.capacity) * this.effIN;
 			double beta_fm = delta_time/(this.capacity * this.effOUT);
 			
 			// update the SOC based on the just written setpoints for the storage

--- a/projects/memapCore/src/main/java/memap/controller/GuiController.java
+++ b/projects/memapCore/src/main/java/memap/controller/GuiController.java
@@ -184,8 +184,9 @@ public class GuiController {
 			String connectedBuilding = obj.get("formattedNameNodeA").getAsString();
 			double pipeLengthInMeter = obj.get("length").getAsDouble();
 			double lossesPer100m = obj.get("losses").getAsDouble();
+			double maxTransportCapacity = obj.get("maxTransportCapacity").getAsDouble();
 
-			return new Connection(sourceBuilding, connectedBuilding, pipeLengthInMeter, lossesPer100m, 1.0);
+			return new Connection(sourceBuilding, connectedBuilding, pipeLengthInMeter, lossesPer100m, maxTransportCapacity);
 		}
 
 	}

--- a/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
+++ b/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
@@ -241,7 +241,7 @@ public class OpcUaBuildingController implements BuildingController {
 							}
 							
 							System.out.println("EMS-Description (nameID) = " + EmsName);
-							ClientEMS ems = new ClientEMS(client, EmsName, triggerId, ConnEffId, 0);
+							ClientEMS ems = new ClientEMS(client, topologyController, EmsName, triggerId, ConnEffId, 0);
 							attach(ems);
 							ems.setTopologyController(topologyController);
 							System.out.println("EMS (" + EMSkey + ") added. ");

--- a/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
+++ b/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
@@ -102,6 +102,7 @@ public class OpcUaBuildingController implements BuildingController {
 		// Subscribe to all devices on the OpcUaServer which are referenced in the
 		// nodesConfig File
 		nodesConfigHandler.initDevices();
+		// TODO: Better way to use House-Name in initDevice class for defining Connections
 	}
 
 	@Override
@@ -236,12 +237,16 @@ public class OpcUaBuildingController implements BuildingController {
 							String EmsName = client.readFinalStringValue(nid0);
 							
 							NodeId ConnEffId = null;
+							String connTo = null;
 							if (topologyController.getOptimizer() == Optimizer.MILPwithConnections) {
 								ConnEffId = NodeId.parse((String) info.get("EffHtNetReceive"));
+								// TODO: This is CoSES hardcoded! Change asap
+								if (name.equals("CoSES_H1")) connTo = "CoSES_H2";
+								if (name.equals("CoSES_H2")) connTo = "CoSES_H1";
 							}
 							
 							System.out.println("EMS-Description (nameID) = " + EmsName);
-							ClientEMS ems = new ClientEMS(client, topologyController, EmsName, triggerId, ConnEffId, 0);
+							ClientEMS ems = new ClientEMS(client, topologyController, EMSkey, name, connTo, triggerId, ConnEffId, 0);
 							attach(ems);
 							ems.setTopologyController(topologyController);
 							System.out.println("EMS (" + EMSkey + ") added. ");

--- a/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
+++ b/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
@@ -16,6 +16,7 @@ import com.google.gson.Gson;
 
 import memap.components.prototypes.Device;
 import memap.helper.HelperUnnestingJSON;
+import memap.helper.configurationOptions.Optimizer;
 import memap.components.ClientDemand;
 import memap.components.ClientEMS;
 import memap.components.ClientCoupler;
@@ -233,8 +234,14 @@ public class OpcUaBuildingController implements BuildingController {
 							NodeId nid0 = NodeId.parse((String) info.get("nameID"));
 							NodeId triggerId = NodeId.parse((String) info.get("trigger")); // Trigger for Synchronization , CoSES-Lab
 							String EmsName = client.readFinalStringValue(nid0);
+							
+							NodeId ConnEffId = null;
+							if (topologyController.getOptimizer() == Optimizer.MILPwithConnections) {
+								ConnEffId = NodeId.parse((String) info.get("EffHtNetReceive"));
+							}
+							
 							System.out.println("EMS-Description (nameID) = " + EmsName);
-							ClientEMS ems = new ClientEMS(client, EmsName, triggerId, 0);
+							ClientEMS ems = new ClientEMS(client, EmsName, triggerId, ConnEffId, 0);
 							attach(ems);
 							ems.setTopologyController(topologyController);
 							System.out.println("EMS (" + EMSkey + ") added. ");
@@ -380,10 +387,8 @@ public class OpcUaBuildingController implements BuildingController {
 								NodeId calculatedSocId = NodeId.parse((String) strge.get("calcSOC"));  // Only available in CoSES
 //								NodeId calculatedSocId = null;
 								NodeId storageLossId = NodeId.parse((String) strge.get("StorLossPD"));
-//								NodeId opCostId = NodeId.parse((String) strge.get("PrimEnCost"));
-								NodeId opCostId = null;
+								NodeId opCostId = NodeId.parse((String) strge.get("PrimEnCost"));
 								NodeId costCO2Id = NodeId.parse((String) strge.get("CO2PerKWh"));
-//								NodeId costCO2Id = null;
 								NodeId inputSetpointId = NodeId.parse((String) strge.get("SPCharge"));
 								NodeId inputSetpointsId = NodeId.parse((String) strge.get("SPChargeAr"));
 //								NodeId inputSetpointsId = null;

--- a/projects/memapCore/src/main/java/memap/helper/SolutionHandler.java
+++ b/projects/memapCore/src/main/java/memap/helper/SolutionHandler.java
@@ -135,64 +135,6 @@ public class SolutionHandler {
 		return result;
 	}
 	
-	/**
-	 * This method will compare the names with the ones from 
-	 * the building messages and will correct the output efficiency
-	 * 
-	 * @param localBuildingMessage
-	 * @param names
-	 * @param optSolution
-	 * @param nStepsMPC
-	 * @return
-	 */
-	public double[] getEffSolutionForThisTimeStep(BuildingMessage lbm, String[] names, double[] optSolution, int nStepsMPC) {
-		// Caution: this method works only for one device per device class !
-		
-		double[] result = new double[optSolution.length / nStepsMPC];
-		
-		ArrayList<ProducerMessage> pm = lbm.controllableProducerList;
-		ArrayList<ProducerMessage> vpm = lbm.volatileProducerList;
-		ArrayList<CouplerMessage> cm = lbm.couplerList;
-		ArrayList<StorageMessage> sm = lbm.storageList;
-		
-		// create loop till maxNr to catch other devices of ne class.
-		int maxNr = Math.max(Math.max(lbm.getNrOfCouplers(), lbm.getNrOfControllableProducers()), Math.max(lbm.getNrOfStorages(), lbm.getNrOfVolatileProducers()));
-//		System.out.println("Numbers: " + lbm.getNrOfCouplers() + lbm.getNrOfControllableProducers() + lbm.getNrOfStorages() + lbm.getNrOfVolatileProducers());
-			
-		try {
-			for (int i = 0; i < result.length; i++) {
-				// get device name at this position
-				String devName = null;
-				if (names[i * nStepsMPC].length() > 3) {
-					devName = names[i * nStepsMPC].substring(0, names[i * nStepsMPC].length() - 3);
-				} else {
-					devName = names[i * nStepsMPC];
-				}
-				// compare device name with building message
-				for (int j = 0; j < maxNr; j++) {	
-					
-					if (lbm.getNrOfControllableProducers() > j && devName.equals(pm.get(j).name)) {
-						result[i] = optSolution[i * nStepsMPC]*pm.get(j).efficiency;
-					} else if (lbm.getNrOfVolatileProducers() > j && devName.equals(vpm.get(j).name)) {
-						result[i] = optSolution[i * nStepsMPC]*vpm.get(j).efficiency;
-					} else if (lbm.getNrOfCouplers() > j && devName.equals(cm.get(j).name)) {
-						// has to be changed to primary efficiency ?
-						result[i] = optSolution[i * nStepsMPC]*cm.get(j).efficiencyHeat;
-					} else if (lbm.getNrOfStorages() > j && devName.equals(sm.get(j).name + "Discharge")) {
-						result[i] = optSolution[i * nStepsMPC]*sm.get(j).efficiencyDischarge;
-					} else if (lbm.getNrOfStorages() > j && devName.equals(sm.get(j).name + "Charge")) {
-						result[i] = optSolution[i * nStepsMPC]*sm.get(j).efficiencyCharge;
-					} else {
-						result[i] = optSolution[i * nStepsMPC];
-					}
-				}
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return result;
-	}
-	
 
 	/**
 	 * @param demand    combined demand vector

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPHelper.java
@@ -1,14 +1,11 @@
 package memap.helper.milp;
 
-import java.util.ArrayList;
-
 import lpsolve.LpSolve;
 import lpsolve.LpSolveException;
 import memap.messages.planning.ConnectionMessage;
 import memap.messages.planning.CouplerMessage;
 import memap.messages.planning.ProducerMessage;
 import memap.messages.planning.StorageMessage;
-import scala.Array;
 
 public abstract class MILPHelper {
 	

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPHelper.java
@@ -1,11 +1,14 @@
 package memap.helper.milp;
 
+import java.util.ArrayList;
+
 import lpsolve.LpSolve;
 import lpsolve.LpSolveException;
 import memap.messages.planning.ConnectionMessage;
 import memap.messages.planning.CouplerMessage;
 import memap.messages.planning.ProducerMessage;
 import memap.messages.planning.StorageMessage;
+import scala.Array;
 
 public abstract class MILPHelper {
 	

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
@@ -137,10 +137,7 @@ public class MILPProblemWithConnections extends MILPProblem {
     	for (BuildingMessage bm : buildingMessages) {
     		mapBuildingMessageToIndex.put(bm, startIndex);
     		
-    		for (int i = 0; i < nStepsMPC; i++) {
-    			
-    			//System.out.println("Current Building: " + bm.name);
-    			
+    		for (int i = 0; i < nStepsMPC; i++) {    			    			
     			int controllableHandled = 0;
                 int volatileHandled = 0;
                 int couplerHandled = 0;
@@ -364,7 +361,7 @@ public class MILPProblemWithConnections extends MILPProblem {
 	    }	// end of nStepsLoop
 
 	     
-	     // TODO connection constraints	     
+	     // this is new content, to consider connection limits
 	     {
 	        	int numberOfNames = problem.getNcolumns();
 	        	
@@ -374,16 +371,12 @@ public class MILPProblemWithConnections extends MILPProblem {
 					nameList.add(j, problem.getColName(j));
 				}
 	        	
-	        	System.out.println(  MILPProblemNoConnections.class + " names: " +  nameList.toString());
-	        	
-	        	for (BuildingMessage bm : buildingMessages) {
-	        		
-	        		System.out.println("BuildingMessage : " + bm.name);
-	        		
+	        	for (BuildingMessage bm : buildingMessages) {	        		        		
 	        		for (ConnectionMessage cm : bm.connectionList) {
-						System.out.println( "Connection: name=" + cm.name + "  from=" + cm.connectedBuildingFrom + " to="+cm.connectedBuildingTo );
+	        			
+						ArrayList<Integer> nameIndices = searchIndexOfConnectionName(cm.name, nameList);
 						
-						for (Integer index : searchIndexOfConnectionName(cm.name, nameList) )  {
+						for (Integer index : nameIndices )  {
 							double[] row = new double[nCols+1];
 							row[index] = 1;
 							problem.addConstraint(row, LpSolve.LE, cm.maxPower);
@@ -401,7 +394,7 @@ public class MILPProblemWithConnections extends MILPProblem {
 		ArrayList<Integer> result = new ArrayList<Integer>();
 				
 		for (int j = 0; j < nameList.size(); j++) {
-			if (nameList.get(j).contains(connectionName)) {
+			if (nameList.get(j) != null && nameList.get(j).contains(connectionName)) {
 				result.add(j);
 			}
 		}
@@ -440,7 +433,7 @@ public class MILPProblemWithConnections extends MILPProblem {
 				double beta_to = delta_time_factor/sm.capacity * sm.efficiencyCharge; // Units [h/kWh]
 				double beta_fm = delta_time_factor/(sm.capacity * sm.efficiencyDischarge); // Units [h/kWh]	
 				
-				int index = indexBuilding + 1 + nStepsMPC * ((controllableHandled * 2)  + volatileHandled + (couplerHandled*2)+ (storageHandled*2)  );		 
+				int index = indexBuilding + nStepsMPC * ((controllableHandled * 2)  + volatileHandled + (couplerHandled*2)+ (storageHandled*2)  );		 
 				
 		        for (int i = 0; i < nStepsMPC; i++) {
 	            	double[] rowCHARGE = new double[nCols+1];

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
@@ -545,7 +545,7 @@ public class MILPProblemWithConnections extends MILPProblem {
 	            	if (topologyController.getToolUsage() == ToolUsage.SERVER && cm.varOperationalCostEUR != null) {
 	            		
 	            		// This part overwrites the previous costs if above condition is given
-	            		counter = counter -1;
+	            		counter--;
 	            		// TODO: solve better
 	            		
 	            		if (topologyController.getOptimizationCriteria() == OptimizationCriteria.EUR) {

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
@@ -359,10 +359,58 @@ public class MILPProblemWithConnections extends MILPProblem {
 	            	//System.out.println("Adding max charging --> row2: " + Arrays.toString(row2) + " <= " + sm.maxLoad);
 	        		        		
 	         		storageHandled++;
-	 			}
-	    	}
-		}
+	 			}	        	
+	    	}	// end of BuildingMessage Loop
+	    }	// end of nStepsLoop
+
+	     
+	     // TODO connection constraints	     
+	     {
+	        	int numberOfNames = problem.getNcolumns();
+	        	
+	        	ArrayList<String> nameList = new ArrayList<>(numberOfNames);
+	        	
+	        	for (int j = 0; j < numberOfNames; j++) {
+					nameList.add(j, problem.getColName(j));
+				}
+	        	
+	        	System.out.println(  MILPProblemNoConnections.class + " names: " +  nameList.toString());
+	        	
+	        	for (BuildingMessage bm : buildingMessages) {
+	        		
+	        		System.out.println("BuildingMessage : " + bm.name);
+	        		
+	        		for (ConnectionMessage cm : bm.connectionList) {
+						System.out.println( "Connection: name=" + cm.name + "  from=" + cm.connectedBuildingFrom + " to="+cm.connectedBuildingTo );
+						
+						for (Integer index : searchIndexOfConnectionName(cm.name, nameList) )  {
+							double[] row = new double[nCols+1];
+							row[index] = 1;
+							problem.addConstraint(row, LpSolve.LE, cm.maxPower);
+						}
+					}
+	        		
+	        		//int index = i + indexBuilding + nStepsMPC * ((controllableHandled * 2)  + volatileHandled + (couplerHandled*2)+ (storageHandled*2)  );
+	        		
+	        		//System.out.println(  MILPProblemNoConnections.class + " cm info " +   );
+	        			        		
+	        	}
+	     }
+	    
 		return problem;
+	}
+	
+	// can be optimized for speed
+	private ArrayList<Integer> searchIndexOfConnectionName(String connectionName, ArrayList<String> nameList) {
+		ArrayList<Integer> result = new ArrayList<Integer>();
+				
+		for (int j = 0; j < nameList.size(); j++) {
+			if (nameList.get(j).contains(connectionName)) {
+				result.add(j);
+			}
+		}
+		
+		return result;
 	}
 
 	public LpSolve createSOCBoundaries(LpSolve problem, ArrayList<BuildingMessage> buildingMessages) throws LpSolveException {

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
@@ -389,10 +389,6 @@ public class MILPProblemWithConnections extends MILPProblem {
 							problem.addConstraint(row, LpSolve.LE, cm.maxPower);
 						}
 					}
-	        		
-	        		//int index = i + indexBuilding + nStepsMPC * ((controllableHandled * 2)  + volatileHandled + (couplerHandled*2)+ (storageHandled*2)  );
-	        		
-	        		//System.out.println(  MILPProblemNoConnections.class + " cm info " +   );
 	        			        		
 	        	}
 	     }

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPSolver.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPSolver.java
@@ -122,8 +122,6 @@ public class MILPSolver {
 			}
 			// TODO Add code to account for the other 14 solver status values. maybe switch
 			// to linear solver instead?
-			// TODO Add some UI warning. When this error takes place the results window does
-			// not appear.
 		}
 	}
 
@@ -141,140 +139,20 @@ public class MILPSolver {
 		workWithResults(optSolution, names, lambda, lambdaCO2);
 	}
 
+	// FIXME - this method is doing two independent tasks, 
 	private void workWithResults(double[] optSolution, String[] names, double[] lambda, double[] lambdaCO2) {
-
-		BuildingMessageHandler buildingMessageHandler = new BuildingMessageHandler();
-		double buildingCostPerTimestep = 0;
-		double buildingCO2PerTimestep = 0;
-		buildingCostPerTimestep = milpSolHandler.calculateTimeStepCosts(optSolution, lambda);
-		buildingCO2PerTimestep = milpSolHandler.calculateTimeStepCosts(optSolution, lambdaCO2);
-		buildingStepCostsMILP[currentTimeStep] = buildingCostPerTimestep;
-		buildingStepCO2MILP[currentTimeStep] = buildingCO2PerTimestep;
-
-		// to calculate the total costs --> what does that say?
 		
-		// System.out.println("buildingCostPerTimestep: " + buildingCostPerTimestep);
+		/** TASK ONE - creation of optResult Map */
 		
-		// is that the total costs of the planned schedule?
-		// is that the cost
-		
-		double costTotal = 0;
-		double CO2Total = 0;
-
-		for (int i = 0; i < buildingStepCostsMILP.length; i++) {
-			costTotal += buildingStepCostsMILP[i];
-			CO2Total += buildingStepCO2MILP[i];
-		}
-		
-		// System.out.println("costTotal: " + costTotal);
-
-		// Creation of the result vector
-		double[] currentStep = { currentTimeStep };
-		
-		// FIXME. Currently there is a bug, because singleBuildingMessage == null, if connections are present! This has to be considered.
-		double[] currentOptVector = null;
-		if (singleBuildingMessage != null) { // Jan's version 
-			currentOptVector = milpSolHandler.getEffSolutionForThisTimeStep(singleBuildingMessage, names, optSolution, nStepsMPC);
-		}
-		
-		if (singleBuildingMessage == null) { // previous solution
-			currentOptVector = milpSolHandler.getSolutionForThisTimeStep(optSolution, nStepsMPC);
-		}
-		
-		double[] currentEnergyPrices = { energyPrices.getElecBuyingPrice(currentTimeStep),
-				energyPrices.getElecSellingPrice(currentTimeStep),
-				energyPrices.getHeatBuyingPrice(currentTimeStep) };
-		double[] totalCostsEUR = { costTotal };
-		double[] totalCO2emissions = { CO2Total };
-
-		String[] timeStep = { Strings.timeStep };
-		String[] currentOptVectorNames = milpSolHandler.getVectorNamesForThisTimeStep(names, nStepsMPC);
-		String[] energyPricesNames = { Strings.elecBuyingPriceAndUnit, Strings.elecSellingPriceAndUnit,
-				Strings.heatBuyingPriceAndUnit };
-		String[] totalCosts = { Strings.totalCostAndUnit };
-		String[] co2emissions = { Strings.co2EmissionsAndUnit };
-
-		String[] currentDemandNames = null;
-		double[] currentDemand = null;
-		
-		String[] currentSOCNames = null;
-		double[] currentSOC = null;
-		
-		String[] currentStorageEnergyContentNames = null;
-		double[] currentStorageEnergyContent = null;
-
-		if (singleBuildingMessage != null) {
-			// Without connections
-			currentDemand = milpSolHandler.getDemandForThisTimestep(singleBuildingMessage.getCombinedDemandVector(),
-					nStepsMPC); 			
-			currentSOC = milpSolHandler.getCurrentSOC(singleBuildingMessage.storageList);
-			currentStorageEnergyContent = milpSolHandler.getCurrentSOCEnergy(singleBuildingMessage.storageList);
-			
-			currentDemandNames = milpSolHandler.getNamesForDemandSingleBuilding();
-			currentSOCNames = milpSolHandler.getNamesForSOC(singleBuildingMessage.storageList);
-			currentStorageEnergyContentNames = milpSolHandler.getNamesForSOCEnergy(singleBuildingMessage.storageList);
-		} else {
-			// With connections
-			double[] demandVector = buildingMessageHandler.getCombinedDemandVector(multipleBuildingMessages, nStepsMPC);
-			currentDemand = milpSolHandler.getDemandForThisTimestep(demandVector, nStepsMPC);			
-			currentSOC = milpSolHandler.getCurrentSOCs(multipleBuildingMessages);
-			currentStorageEnergyContent = milpSolHandler.getCurrentSOCEnergyMB(multipleBuildingMessages);
-			
-			currentDemandNames = milpSolHandler.getNamesForDemand(multipleBuildingMessages, nStepsMPC);
-			currentSOCNames = milpSolHandler.getNamesForSOCs(multipleBuildingMessages);
-			currentStorageEnergyContentNames = milpSolHandler.getNamesForSOCEnergyMB(multipleBuildingMessages);
-			
-			//Small modification to calculate the aggregated demand of the buildings.
-			double[] resultWithTotalHeatDemand = new double[currentDemand.length+1];			
-			for (int i = 0; i < currentDemand.length -1; i++) {
-				resultWithTotalHeatDemand[0] += currentDemand[i];
-				resultWithTotalHeatDemand[i+1] = currentDemand[i];
-			}			
-			resultWithTotalHeatDemand[currentDemand.length] = currentDemand[currentDemand.length-1];			
-			currentDemand = resultWithTotalHeatDemand;
-		}
-
-		String[] namesResult = HelperConcat.concatAllObjects(timeStep, currentDemandNames, currentOptVectorNames,
-				currentSOCNames, currentStorageEnergyContentNames, energyPricesNames, totalCosts, co2emissions);
-		double[] vectorResult = HelperConcat.concatAlldoubles(currentStep, currentDemand, currentOptVector, currentSOC,
-				currentStorageEnergyContent, currentEnergyPrices, totalCostsEUR, totalCO2emissions);
-
-		
-		int nrOfBuildings = 1;
-		if (singleBuildingMessage == null) {
-			nrOfBuildings =  multipleBuildingMessages.size();
-		}
-		
-		if (topologyController.getToolUsage() == ToolUsage.SERVER) {
-			ConnectionDB.addResults(topologyController.getOptimizationHierarchy(),currentTimeStep, namesResult, currentStep, currentDemand, currentOptVector, currentSOC,
-				currentEnergyPrices, totalCostsEUR, totalCO2emissions, nrOfBuildings);
-		}
-		
-
-		// Format results vector for printing
-		String[] vectorResultStr = new String[vectorResult.length];
-		DecimalFormat df = new DecimalFormat("0,00", new DecimalFormatSymbols(Locale.GERMAN));
-		for (int i = 1; i < vectorResultStr.length; i++) {
-			vectorResultStr[i] = df.format(vectorResult[i]);
-		}
-
-		//System.out.println("MILP: " + this.actorName + " Names: " + Arrays.toString(namesResult));
-		//System.out.println("MILP: " + this.actorName + " Result: " + Arrays.toString(vectorResult));
-		
-		
-		// Save
-		buildingsSolutionPerTimeStepMILP[currentTimeStep] = vectorResult;
-
-		String saveString = topologyController.getSimulationName() + "/MPC" + topologyConfig.getNrStepsMPC() + "_MILP/";
-		saveString += actorName + "_MPC" + nStepsMPC + Strings.milpSolutionFileSuffix;
-		if (currentTimeStep == (topologyConfig.getNrOfIterations() - 1)) {
-			milpSolHandler.exportMatrix(buildingsSolutionPerTimeStepMILP, saveString, namesResult);
-		}
-
-		/* FIXME this is workaround due to merge of the branches from server team and planning tool team
+		/* FIXME - done below 
+		 * 
+		 * 
+		 * this is workaround due to merge of the branches from server team and planning tool team
 		 * it would be good to get a harmonic solution, where the solution is corrected by efficiencies in both cases, 
 		 * no matter if it is a solution of the problem with connections, or without. 
 		 */
+		
+		/** OLD Code 
 		double[] optSolutionEffcorrected = null;
 		if (singleBuildingMessage != null) {
 			optSolutionEffcorrected = milpSolHandler.getEffSolutionForThisTimeStep(singleBuildingMessage, names, optSolution, 1);
@@ -283,7 +161,12 @@ public class MILPSolver {
 			optSolutionEffcorrected = optSolution;
 		}
 		
+		// TODO change the method above.
+				
+		// System.out.println(MILPSolver.class + " names[]: " + Arrays.toString(names));
+		// System.out.println(MILPSolver.class + " optSolution[]: " + Arrays.toString(optSolution));
 		
+		// optSolutionEffcorrected = null;
 		
 		// Request content to send
 		for (int i = 0; i < names.length / nStepsMPC; i++) {
@@ -300,8 +183,207 @@ public class MILPSolver {
 
 			optResult.resultMap.put(str, values);
 		}
+		*/
+		
+		/** THIS IS A MODIFACTION TO CONSIDER THE EFFICIENCIES AS WELL */
+		
+		ArrayList<String> additionalEfficiencyNames_tmp = null;
+		ArrayList<Double> additionalEfficiencyValues_tmp = null;
+		
+		if (singleBuildingMessage != null) {
+			additionalEfficiencyNames_tmp = milpSolHandler.createNamesForCorrEfficiency(singleBuildingMessage, names);
+			additionalEfficiencyValues_tmp = milpSolHandler.createValuesForCorrEfficiency(singleBuildingMessage, names, optSolution);
+			
+		} else if (multipleBuildingMessages != null) {
+			additionalEfficiencyNames_tmp = milpSolHandler.createNamesForCorrEfficiency(multipleBuildingMessages, names);
+			additionalEfficiencyValues_tmp = milpSolHandler.createValuesForCorrEfficiency(multipleBuildingMessages, names, optSolution);
+		}
+		
+		/* cast the ArrayList<String> and ArrayList<Double> to conventional Java arrays-[] */ 
+		String[] additionalEfficiencyNames = new String[additionalEfficiencyNames_tmp.size()];
+		additionalEfficiencyNames = additionalEfficiencyNames_tmp.toArray(additionalEfficiencyNames);
+		
+		double[] additionalEfficiencyValues = new double[additionalEfficiencyValues_tmp.size()];				
+		for (int i = 0; i < additionalEfficiencyValues.length; i++) {
+			additionalEfficiencyValues[i] = additionalEfficiencyValues_tmp.get(i);
+		} // casting done here
+		
+		
+		// new code to correct the old code, that is commented out above
+		// TODO - needs to be checked
+		double[] extendedSolutionVector = HelperConcat.concatAlldoubles(
+					optSolution, 
+					additionalEfficiencyValues
+				);
+		
+		String[] extendedNames = HelperConcat.concatAllObjects(
+					names, 
+					additionalEfficiencyNames
+				);
+		
+		for (int i = 0; i < extendedNames.length / nStepsMPC; i++) {
+			double[] values = new double[nStepsMPC];
+
+			for (int j = 0; j < values.length; j++) {
+				values[j] = extendedSolutionVector[i * nStepsMPC + j];
+			}
+
+			String str = extendedNames[i * nStepsMPC].replace("_T0", "");
+
+			optResult.resultMap.put(str, values);
+		}
 
 		// Memory is cleaned up in the child classes 
+		
+		
+		/** TASK TWO - creation of result vectors for current time step for planning tool */
+
+		double buildingCostPerTimestep = 0;
+		double buildingCO2PerTimestep = 0;
+		buildingCostPerTimestep = milpSolHandler.calculateTimeStepCosts(optSolution, lambda);
+		buildingCO2PerTimestep = milpSolHandler.calculateTimeStepCosts(optSolution, lambdaCO2);
+		buildingStepCostsMILP[currentTimeStep] = buildingCostPerTimestep;
+		buildingStepCO2MILP[currentTimeStep] = buildingCO2PerTimestep;
+		
+		double costTotal = 0;
+		double CO2Total = 0;
+
+		for (int i = 0; i < buildingStepCostsMILP.length; i++) {
+			costTotal += buildingStepCostsMILP[i];
+			CO2Total += buildingStepCO2MILP[i];
+		}
+
+		/** Creation of the two result vectors, one with name, one with values **/
+		String[] timeStep = { Strings.timeStep };
+		double[] currentStep = { currentTimeStep };
+		
+		String[] energyPricesNames = { 
+					Strings.elecBuyingPriceAndUnit, 
+					Strings.elecSellingPriceAndUnit,
+					Strings.heatBuyingPriceAndUnit 
+				};
+		
+		double[] currentEnergyPrices = { 
+					energyPrices.getElecBuyingPrice(currentTimeStep),
+					energyPrices.getElecSellingPrice(currentTimeStep),
+					energyPrices.getHeatBuyingPrice(currentTimeStep) 
+				};
+		
+		String[] totalCosts = { Strings.totalCostAndUnit };
+		double[] totalCostsEUR = { costTotal };
+		
+		String[] co2emissions = { Strings.co2EmissionsAndUnit };
+		double[] totalCO2emissions = { CO2Total };
+		
+		String[] currentOptVectorNames = milpSolHandler.getVectorNamesForThisTimeStep(names, nStepsMPC);
+		double[] currentOptVector = milpSolHandler.getSolutionForThisTimeStep(optSolution, nStepsMPC);
+		
+		System.out.println(MILPSolver.class + " additionalEfficiencyNames: " + Arrays.toString(additionalEfficiencyNames));
+		System.out.println(MILPSolver.class + " additionalEfficiencyValues: " + Arrays.toString(additionalEfficiencyValues));
+		
+		// filter the right names
+		int[] selectedIndices = milpSolHandler.getIndicesByTO(additionalEfficiencyNames, nStepsMPC); 
+		String[] currentEfficiencyNames = new String[selectedIndices.length];
+		double[] currentEfficiencyValues = new double[selectedIndices.length];
+		
+		for (int i = 0; i < selectedIndices.length; i++) {
+			currentEfficiencyNames[i] = additionalEfficiencyNames[selectedIndices[i]].replace("_T0", "");
+			currentEfficiencyValues[i] = additionalEfficiencyValues[selectedIndices[i]];
+		}
+		
+		System.out.println(MILPSolver.class + " currentEfficiencyNames: " + Arrays.toString(currentEfficiencyNames));
+		System.out.println(MILPSolver.class + " currentEfficiencyProdValues: " + Arrays.toString(currentEfficiencyValues));
+
+		String[] currentDemandNames = null;
+		double[] currentDemand = null;
+		
+		String[] currentSOCNames = null;
+		double[] currentSOC = null;
+		
+		String[] currentStorageEnergyContentNames = null;
+		double[] currentStorageEnergyContent = null;
+
+		if (singleBuildingMessage != null) {
+			// Without connections
+			currentDemand = milpSolHandler.getDemandForThisTimestep(singleBuildingMessage.getCombinedDemandVector(),
+					nStepsMPC); 			
+			currentSOC = milpSolHandler.getCurrentSOC(singleBuildingMessage.storageList);
+			currentStorageEnergyContent = milpSolHandler.getCurrentSOCEnergy(singleBuildingMessage.storageList);			
+			currentDemandNames = milpSolHandler.getNamesForDemandSingleBuilding();
+			currentSOCNames = milpSolHandler.getNamesForSOC(singleBuildingMessage.storageList);
+			currentStorageEnergyContentNames = milpSolHandler.getNamesForSOCEnergy(singleBuildingMessage.storageList);
+			
+		} else {
+			// With connections
+			BuildingMessageHandler buildingMessageHandler = new BuildingMessageHandler();
+			double[] demandVector = buildingMessageHandler.getCombinedDemandVector(multipleBuildingMessages, nStepsMPC);
+			
+			currentDemand = milpSolHandler.getDemandForThisTimestep(demandVector, nStepsMPC);
+			currentSOC = milpSolHandler.getCurrentSOCs(multipleBuildingMessages);
+			currentStorageEnergyContent = milpSolHandler.getCurrentSOCEnergyMB(multipleBuildingMessages);
+			
+			currentDemandNames = milpSolHandler.getNamesForDemand(multipleBuildingMessages, nStepsMPC);
+			currentSOCNames = milpSolHandler.getNamesForSOCs(multipleBuildingMessages);
+			currentStorageEnergyContentNames = milpSolHandler.getNamesForSOCEnergyMB(multipleBuildingMessages);
+			
+			//Small modification to calculate the aggregated demand of the buildings.
+			double[] resultWithTotalHeatDemand = new double[currentDemand.length+1];			
+			for (int i = 0; i < currentDemand.length -1; i++) {
+				resultWithTotalHeatDemand[0] += currentDemand[i];
+				resultWithTotalHeatDemand[i+1] = currentDemand[i];
+			}
+			resultWithTotalHeatDemand[currentDemand.length] = currentDemand[currentDemand.length-1];			
+			currentDemand = resultWithTotalHeatDemand;
+		}		
+
+		String[] namesResult_this_TimeStep = HelperConcat.concatAllObjects(
+				timeStep, 
+				currentDemandNames, 
+				currentOptVectorNames, 				
+				currentEfficiencyNames,				
+				currentSOCNames, 
+				currentStorageEnergyContentNames, 
+				energyPricesNames, 
+				totalCosts, 
+				co2emissions);
+		
+		double[] vectorResult_this_TimeStep = HelperConcat.concatAlldoubles(
+				currentStep, 
+				currentDemand, 
+				currentOptVector,				
+				currentEfficiencyValues,				
+				currentSOC,
+				currentStorageEnergyContent, 
+				currentEnergyPrices, 
+				totalCostsEUR, 
+				totalCO2emissions);
+
+		// FIXME - check if the "ToolUsage.SERVER" part has to be adapted to the changes above as well.
+		int nrOfBuildings = 1;
+		if (singleBuildingMessage == null) {
+			nrOfBuildings =  multipleBuildingMessages.size();
+		}
+		
+		if (topologyController.getToolUsage() == ToolUsage.SERVER) {
+			ConnectionDB.addResults(topologyController.getOptimizationHierarchy(),currentTimeStep, namesResult_this_TimeStep, currentStep, currentDemand, currentOptVector, currentSOC,
+				currentEnergyPrices, totalCostsEUR, totalCO2emissions, nrOfBuildings);
+		}		
+
+		// Format results vector for printing
+		String[] vectorResultStr = new String[vectorResult_this_TimeStep.length];
+		DecimalFormat df = new DecimalFormat("0,00", new DecimalFormatSymbols(Locale.GERMAN));
+		for (int i = 1; i < vectorResultStr.length; i++) {
+			vectorResultStr[i] = df.format(vectorResult_this_TimeStep[i]);
+		}
+		
+		// Save
+		buildingsSolutionPerTimeStepMILP[currentTimeStep] = vectorResult_this_TimeStep;
+
+		String saveString = topologyController.getSimulationName() + "/MPC" + topologyConfig.getNrStepsMPC() + "_MILP/";
+		saveString += actorName + "_MPC" + nStepsMPC + Strings.milpSolutionFileSuffix;
+		if (currentTimeStep == (topologyConfig.getNrOfIterations() - 1)) {
+			milpSolHandler.exportMatrix(buildingsSolutionPerTimeStepMILP, saveString, namesResult_this_TimeStep);
+		}
 
 	}
 

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPSolverWithConnections.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPSolverWithConnections.java
@@ -19,6 +19,10 @@ import memap.messages.BuildingMessage;
 import memap.messages.OptimizationResultMessage;
 
 /**
+ * The Solver Class is the major interface to work through our optimization.
+ * The Solver uses the Problem class to define the Optimization and call the
+ * related methods step-by-step.
+ * 
  * Note, this class might have many cloning from MILP with no connections, we
  * are trying to remove as many clones as possible, after finishing the correct
  * implementation of MILP.

--- a/projects/memapCore/src/main/java/memap/main/JettyStart.java
+++ b/projects/memapCore/src/main/java/memap/main/JettyStart.java
@@ -72,7 +72,7 @@ public class JettyStart {
 
 	public void run(JsonObject memapStartMessage) {
 
-		topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILP,
+		topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILPwithConnections,
 				OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.RESULTS_ONLY);
 
 		TopologyConfig.getInstance().init(Simulation.N_STEPS_MPC, 96, 30, 7020, 0);

--- a/projects/memapCore/src/main/java/memap/main/JettyStart.java
+++ b/projects/memapCore/src/main/java/memap/main/JettyStart.java
@@ -73,7 +73,7 @@ public class JettyStart {
 	public void run(JsonObject memapStartMessage) {
 
 		topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILPwithConnections,
-				OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.RESULTS_ONLY);
+				OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.ALL);
 
 		TopologyConfig.getInstance().init(Simulation.N_STEPS_MPC, 96, 30, 7020, 0);
 		System.out.println(">> MPC set to " + Simulation.N_STEPS_MPC);


### PR DESCRIPTION
This feature integrates the possibility to use heat-connection between local EMS in live mode. 
(Solver: MILPWithConnections)

At the moment, this is a test-scenario only working in the CoSES laboratory (TUM). For general use, a heat-network-topology matrix has to be included as input, so that the connections between the respective buildings can be generated from it.

Changes:
 * the ClientEMS class now extends `Connection` and generates the ConnectionMessage (only one per building atm)
 * the connection efficiency is read from the opc ua server and can be modified before start-up (not during runtime)
 * solution for CPROD and COUPL are extended by additional efficiency-corrected values, which are used as setpoints. These changes replace a previous method in SolutionHandler.

Testing in CoSES still has to be done.