### PR TITLE
Export of topology-json using some helper classes from memapGui

### DIFF
--- a/projects/memapCore/src/main/java/memap/components/prototypes/MEMAPCoordination.java
+++ b/projects/memapCore/src/main/java/memap/components/prototypes/MEMAPCoordination.java
@@ -1,6 +1,8 @@
 package memap.components.prototypes;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.google.gson.Gson;
 
@@ -12,17 +14,31 @@ import behavior.BehaviorModel;
 import lpsolve.LpSolveException;
 import memap.controller.TopologyController;
 import memap.helper.SolutionHandler;
+import memap.helper.JsonExportHelper.BuildingJsonHelper;
+import memap.helper.JsonExportHelper.CouplerJsonHelper;
+import memap.helper.JsonExportHelper.DemandJsonHelper;
+import memap.helper.JsonExportHelper.ParameterJsonHelper;
+import memap.helper.JsonExportHelper.PriceJsonHelper;
+import memap.helper.JsonExportHelper.ProducerJsonHelper;
+import memap.helper.JsonExportHelper.StorageJsonHelper;
+import memap.helper.JsonExportHelper.VolatileJsonHelper;
 import memap.helper.configurationOptions.OptHierarchy;
 import memap.helper.configurationOptions.Optimizer;
 import memap.helper.configurationOptions.ToolUsage;
 import memap.helper.lp.LPSolver;
 import memap.helper.milp.MILPSolverNoConnections;
 import memap.helper.milp.MILPSolverWithConnections;
+import memap.helperOPCua.OpcServerContextGenerator;
+import memap.main.Simulation;
 import memap.main.TopologyConfig;
 import memap.messages.BuildingMessage;
 import memap.messages.BuildingMessageHandler;
 import memap.messages.OptimizationResultMessage;
 import memap.messages.extension.ChildSpecification;
+import memap.messages.planning.CouplerMessage;
+import memap.messages.planning.DemandMessage;
+import memap.messages.planning.ProducerMessage;
+import memap.messages.planning.StorageMessage;
 import opcMEMAP.MemapOpcServerStarter;
 /**
  * This model optimizes over several buildings for the planning tool.
@@ -170,6 +186,69 @@ public class MEMAPCoordination extends BehaviorModel implements CurrentTimeStepS
 					e.printStackTrace();
 				}
 			}
+			
+			
+			// Option to save topology as json for usage in planning tool:
+			if (true) {			
+				if (currentTimeStep == 0) { 
+					ArrayList<Object> list = new ArrayList<Object>();
+					Set<BuildingJsonHelper> buildingSet = new HashSet<BuildingJsonHelper>();
+					BuildingJsonHelper bjh = null;
+					
+					for (BasicAnswer basicAnswer : answerListReceived) {
+						AnswerContent answerContent = basicAnswer.answerContent;
+						if (answerContent instanceof BuildingMessage) {
+							BuildingMessage bmsg = (BuildingMessage) answerContent;
+												
+							bjh = new BuildingJsonHelper(bmsg);
+							
+							for (DemandMessage dm : bmsg.demandList) {
+								DemandJsonHelper djh = new DemandJsonHelper(dm);
+								bjh.addDemand(djh);
+							}
+							for (CouplerMessage cm : bmsg.couplerList) {
+								CouplerJsonHelper cjh = new CouplerJsonHelper(cm);
+								bjh.addCoupler(cjh);
+							}
+							for (ProducerMessage pm : bmsg.controllableProducerList) {
+								ProducerJsonHelper pjh = new ProducerJsonHelper(pm);
+								bjh.addContProduction(pjh);
+							}
+							for (ProducerMessage vpm : bmsg.volatileProducerList) {
+								VolatileJsonHelper vjh = new VolatileJsonHelper(vpm);
+								bjh.addVolProduction(vjh);
+							}
+							for (StorageMessage sm : bmsg.storageList) {
+								StorageJsonHelper sjh = new StorageJsonHelper(sm);
+								bjh.addStorage(sjh);
+							}
+						}
+					buildingSet.add(bjh);
+					}
+					list.add(buildingSet);
+					
+					Set<Object> connections = new HashSet<Object>();
+					list.add(connections);
+					
+					Set<ParameterJsonHelper> parameterSet = new HashSet<ParameterJsonHelper>();
+					ParameterJsonHelper paramjh = new ParameterJsonHelper(
+							96,
+							Simulation.N_STEPS_MPC,
+							2,
+							topologyController.getOptimizationCriteria().toString(),
+							topologyController.getOptimizer().toString(),
+							topologyController.getLogging().toString(),
+							new PriceJsonHelper(true, 0.3, "", Simulation.N_STEPS_MPC),   // elecBuyingPrice
+							new PriceJsonHelper(true, 0.08, "", Simulation.N_STEPS_MPC),  // elecSellingPrice
+							new PriceJsonHelper(true, 0.13, "", Simulation.N_STEPS_MPC),  // heatBuyingPrice
+							new PriceJsonHelper(true, 0.404, "", Simulation.N_STEPS_MPC)  // co2Emissions
+							);
+					parameterSet.add(paramjh);
+					list.add(parameterSet);
+					// gson.toJson(list, new FileWriter("PATH\\OutputForPlanningTool.json"));
+					OpcServerContextGenerator.generateJson(this.actorName + "_forPlanningTool", list);
+				}
+			}		
 		}
 		
 		return buildingMessage;

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
@@ -1,0 +1,34 @@
+package memap.helper.JsonExportHelper;
+
+import java.awt.geom.Point2D;
+
+import com.google.gson.annotations.Expose;
+
+public class BuildingIconJsonHelper {
+
+	@Expose
+	private Point2D position;
+	
+	public BuildingIconJsonHelper(int i) {
+		
+		Point2D defaultposition = new Point2D.Double(391 + 5*i, 206 + 5*i);
+		
+		setPosition(defaultposition);		
+	}
+	
+	/**
+	 * @return the position
+	 */
+	public Point2D getPosition() {
+		return position;
+	}
+
+	/**
+	 * @param position the position to set
+	 */
+	public void setPosition(Point2D position) {
+		this.position = position;
+	}
+	
+	
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
@@ -9,23 +9,15 @@ public class BuildingIconJsonHelper {
 	@Expose
 	private Point2D position;
 	
-	public BuildingIconJsonHelper(int i) {
-		
+	public BuildingIconJsonHelper(int i) {	
 		Point2D defaultposition = new Point2D.Double(391 + 5*i, 206 + 5*i);
-		
 		setPosition(defaultposition);		
 	}
 	
-	/**
-	 * @return the position
-	 */
 	public Point2D getPosition() {
 		return position;
 	}
 
-	/**
-	 * @param position the position to set
-	 */
 	public void setPosition(Point2D position) {
 		this.position = position;
 	}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
@@ -28,24 +28,15 @@ public class BuildingJsonHelper {
 	private ArrayList<VolatileJsonHelper> volatile_list = new ArrayList<VolatileJsonHelper>();
 	@Expose
 	private ArrayList<StorageJsonHelper> storage_list = new ArrayList<StorageJsonHelper>();
-
 	@Expose
 	private BuildingIconJsonHelper icon = new BuildingIconJsonHelper(0);
 
-//	/**
-//	 * Constructor for class Building
-//	 * 
-//	 * @param name an alphanumeric string
-//	 * @param port an integer between 1024 and 49151, or 0
-//	 * 
-//	 */
+	
 	public BuildingJsonHelper(BuildingMessage buildingMessage) {
-		// Do not use setName() in the constructor!
 
 		this.name = buildingMessage.name;
 		setFormattedName(name);
 		this.setPort(port);
-
 	}
 
 	public String getName() {
@@ -75,18 +66,6 @@ public class BuildingJsonHelper {
 		this.port = port;
 	}
 
-	
-	
-//	public ArrayList<Device> getComponents(){
-//		ArrayList<Device> components = new ArrayList<Device>();
-//		components.addAll(demand_list);
-//		components.addAll(storage_list);
-//		components.addAll(volatile_list);
-//		components.addAll(controllable_list);
-//		components.addAll(coupler_list);
-//		return components;
-//	}
-
 	public void addCoupler(CouplerJsonHelper coupler) {
 		coupler_list.add(coupler);
 	}
@@ -106,6 +85,5 @@ public class BuildingJsonHelper {
 	public void addDemand(DemandJsonHelper demand) {
 		demand_list.add(demand);
 	}
-
 
 }

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
@@ -1,0 +1,111 @@
+package memap.helper.JsonExportHelper;
+
+import java.util.ArrayList;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.BuildingMessage;
+
+/**
+ * Building is the class for representing Energy Management Systems (EMS).
+ */
+public class BuildingJsonHelper {
+	
+	@Expose
+	private String name;
+	@Expose
+	protected String formattedName;
+	@Expose
+	private int port;
+
+	@Expose
+	private ArrayList<DemandJsonHelper> demand_list = new ArrayList<DemandJsonHelper>();
+	@Expose
+	private ArrayList<CouplerJsonHelper> coupler_list = new ArrayList<CouplerJsonHelper>();
+	@Expose
+	private ArrayList<ProducerJsonHelper> controllable_list = new ArrayList<ProducerJsonHelper>();
+	@Expose
+	private ArrayList<VolatileJsonHelper> volatile_list = new ArrayList<VolatileJsonHelper>();
+	@Expose
+	private ArrayList<StorageJsonHelper> storage_list = new ArrayList<StorageJsonHelper>();
+
+	@Expose
+	private BuildingIconJsonHelper icon = new BuildingIconJsonHelper(0);
+
+//	/**
+//	 * Constructor for class Building
+//	 * 
+//	 * @param name an alphanumeric string
+//	 * @param port an integer between 1024 and 49151, or 0
+//	 * 
+//	 */
+	public BuildingJsonHelper(BuildingMessage buildingMessage) {
+		// Do not use setName() in the constructor!
+
+		this.name = buildingMessage.name;
+		setFormattedName(name);
+		this.setPort(port);
+
+	}
+
+	public String getName() {
+		return name;
+	}
+	
+	public String getFormattedName() {		
+		if (formattedName == null) return name;		
+		return formattedName;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+		setFormattedName(name);
+	}
+	
+	public void setFormattedName(String name) {
+		this.formattedName = name.replace("Ä", "Ae").replace("Ö", "Oe").replace("Ü", "Ue").replace("ä", "ae")
+				.replace("ö", "oe").replace("ü", "ue").replace("ß", "ss");
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	
+	
+//	public ArrayList<Device> getComponents(){
+//		ArrayList<Device> components = new ArrayList<Device>();
+//		components.addAll(demand_list);
+//		components.addAll(storage_list);
+//		components.addAll(volatile_list);
+//		components.addAll(controllable_list);
+//		components.addAll(coupler_list);
+//		return components;
+//	}
+
+	public void addCoupler(CouplerJsonHelper coupler) {
+		coupler_list.add(coupler);
+	}
+
+	public void addContProduction(ProducerJsonHelper cont_production) {
+		controllable_list.add(cont_production);
+	}
+
+	public void addVolProduction(VolatileJsonHelper vol_production) {
+		volatile_list.add(vol_production);
+	}
+
+	public void addStorage(StorageJsonHelper storage) {
+		storage_list.add(storage);
+	}
+	
+	public void addDemand(DemandJsonHelper demand) {
+		demand_list.add(demand);
+	}
+
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/CouplerJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/CouplerJsonHelper.java
@@ -1,0 +1,133 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.CouplerMessage;
+
+/**
+ * Coupler is the class for representing Coupler objects. Example: CHP, HeatPump
+ */
+public class CouplerJsonHelper{
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkTypeP; // Primary, Values: Heat or Electricity
+	@Expose
+	private String networkTypeS; // Secondary, Values: Heat or Electricity
+	@Expose
+	private double minimumPower;
+	@Expose
+	private double maximumPower;
+	@Expose
+	private double efficiencyPrimary;
+	@Expose
+	private double efficiencySecondary;
+	@Expose
+	private double cost;
+	@Expose
+	private double coEmission;
+
+	/**
+	 * Constructor for class Coupler
+	 * 
+	 * @param name                an alphanumeric string
+	 * @param networkTypeP        primary network type. A string: Heat or
+	 *                            Electricity
+	 * @param networkTypeS        secondary network type. A string: Heat or
+	 *                            Electricity
+	 * @param minimumPower        a positive double [kW]
+	 * @param maximumPower        a positive double [kW]
+	 * @param efficiencyPrimary   primary network efficiency. A positive double
+	 * @param efficiencySecondary secondary network efficiency. A negative double
+	 * @param cost                cost [EUR]
+	 * @param coEmission          CO2 Emissions measured in [g/kWh]
+	 */
+	public CouplerJsonHelper(CouplerMessage couplerMessage) {
+
+		setName(couplerMessage.name);
+		setNetworkTypeP(couplerMessage.primaryNetwork);
+		setNetworkTypeS(couplerMessage.secondaryNetwork);
+		setMinimumPower(couplerMessage.minPower);
+		setMaximumPower(couplerMessage.maxPower);
+		// TODO: Problem! Primary/Secondary Efficiency in Coupler Message!
+		setEfficiencyPrimary(couplerMessage.efficiencyHeat);
+		setEfficiencySecondary(couplerMessage.efficiencyElec);
+		setCost(couplerMessage.operationalCostEUR);
+		setCOEmission(couplerMessage.operationalCostCO2);
+
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getNetworkTypeP() {
+		return networkTypeP;
+	}
+
+	public void setNetworkTypeP(NetworkType networkTypeP) {
+		this.networkTypeP = networkTypeP.toString();
+	}
+
+	public String getNetworkTypeS() {
+		return networkTypeS;
+	}
+
+	public void setNetworkTypeS(NetworkType networkTypeS) {
+		this.networkTypeS = networkTypeS.toString();
+	}
+
+	public double getMinimumPower() {
+		return minimumPower;
+	}
+
+	public void setMinimumPower(double minimumPower) {
+		this.minimumPower = minimumPower;
+	}
+
+	public double getMaximumPower() {
+		return maximumPower;
+	}
+
+	public void setMaximumPower(double maximumPower) {
+		this.maximumPower = maximumPower;
+	}
+
+	public double getEfficiencyPrimary() {
+		return efficiencyPrimary;
+	}
+
+	public void setEfficiencyPrimary(double efficiencyNetworkP) {
+		this.efficiencyPrimary = efficiencyNetworkP;
+	}
+
+	public double getEfficiencySecondary() {
+		return efficiencySecondary;
+	}
+
+	public void setEfficiencySecondary(double efficiencyNetworkS) {
+		this.efficiencySecondary = efficiencyNetworkS;
+	}
+
+	public double getCost() {
+		return cost;
+	}
+
+	public void setCost(double cost) {
+		this.cost = cost;
+	}
+
+	public double getCOEmission() {
+		return coEmission;
+	}
+
+	public void setCOEmission(double coEmission) {
+		this.coEmission = coEmission;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/DemandJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/DemandJsonHelper.java
@@ -1,0 +1,45 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.planning.DemandMessage;
+
+/**
+ * Demand is the class for representing Consumers.
+ */
+public class DemandJsonHelper {
+
+	@Expose
+	private String consumptionProfile;
+	@Expose
+	private String name;
+
+	/**
+	 * Constructor for class Demand
+	 * 
+	 * @param name               an alphanumeric string
+	 * @param index              an positive integer
+	 * @param consumptionProfile a path to an existing file
+	 * @param networkType        a string: Heat or Electricity
+	 */
+	public DemandJsonHelper(DemandMessage demandMessage) {
+		setName(demandMessage.name);
+		setConsumptionProfile("");
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+	public String getConsumptionProfile() {
+		return consumptionProfile;
+	}
+
+	public void setConsumptionProfile(String consumptionFile) {
+		this.consumptionProfile = consumptionFile;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/JsonExportHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/JsonExportHelper.java
@@ -1,0 +1,82 @@
+package memap.helper.JsonExportHelper;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import akka.basicMessages.AnswerContent;
+import akka.basicMessages.BasicAnswer;
+import memap.controller.TopologyController;
+import memap.helper.EnergyPrices;
+import memap.helperOPCua.OpcServerContextGenerator;
+import memap.main.Simulation;
+import memap.main.TopologyConfig;
+import memap.messages.BuildingMessage;
+import memap.messages.planning.CouplerMessage;
+import memap.messages.planning.DemandMessage;
+import memap.messages.planning.ProducerMessage;
+import memap.messages.planning.StorageMessage;
+
+public class JsonExportHelper {
+
+	public static void exportMemapTopology(TopologyController topologyController, ArrayList<BasicAnswer> answerListReceived) {
+		ArrayList<Object> list = new ArrayList<Object>();
+		Set<BuildingJsonHelper> buildingSet = new HashSet<BuildingJsonHelper>();
+		BuildingJsonHelper bjh = null;
+		
+		for (BasicAnswer basicAnswer : answerListReceived) {
+			AnswerContent answerContent = basicAnswer.answerContent;
+			if (answerContent instanceof BuildingMessage) {
+				BuildingMessage bmsg = (BuildingMessage) answerContent;
+									
+				bjh = new BuildingJsonHelper(bmsg);
+				
+				for (DemandMessage dm : bmsg.demandList) {
+					DemandJsonHelper djh = new DemandJsonHelper(dm);
+					bjh.addDemand(djh);
+				}
+				for (CouplerMessage cm : bmsg.couplerList) {
+					CouplerJsonHelper cjh = new CouplerJsonHelper(cm);
+					bjh.addCoupler(cjh);
+				}
+				for (ProducerMessage pm : bmsg.controllableProducerList) {
+					ProducerJsonHelper pjh = new ProducerJsonHelper(pm);
+					bjh.addContProduction(pjh);
+				}
+				for (ProducerMessage vpm : bmsg.volatileProducerList) {
+					VolatileJsonHelper vjh = new VolatileJsonHelper(vpm);
+					bjh.addVolProduction(vjh);
+				}
+				for (StorageMessage sm : bmsg.storageList) {
+					StorageJsonHelper sjh = new StorageJsonHelper(sm);
+					bjh.addStorage(sjh);
+				}
+			}
+		buildingSet.add(bjh);
+		}
+		list.add(buildingSet);
+		
+		Set<Object> connections = new HashSet<Object>();
+		list.add(connections);
+		
+		Set<ParameterJsonHelper> parameterSet = new HashSet<ParameterJsonHelper>();
+		ParameterJsonHelper paramjh = new ParameterJsonHelper(
+				TopologyConfig.getInstance().getTimeStepsPerDay(),
+				Simulation.N_STEPS_MPC,
+				TopologyConfig.getInstance().getNrDays(),
+				topologyController.getOptimizationCriteria().toString(),
+				topologyController.getOptimizer().toString(),
+				topologyController.getLogging().toString(),
+				new PriceJsonHelper(true, EnergyPrices.getInstance().getElecBuyingPrice(0), "", Simulation.N_STEPS_MPC),   // elecBuyingPrice
+				new PriceJsonHelper(true, EnergyPrices.getInstance().getElecSellingPrice(0), "", Simulation.N_STEPS_MPC),  // elecSellingPrice
+				new PriceJsonHelper(true, EnergyPrices.getInstance().getHeatBuyingPrice(0), "", Simulation.N_STEPS_MPC),  // heatBuyingPrice
+				new PriceJsonHelper(true, 0.404, "", Simulation.N_STEPS_MPC)  // co2Emissions
+				);
+		parameterSet.add(paramjh);
+		list.add(parameterSet);
+
+		OpcServerContextGenerator.generateJson("ExportForPlanningTool", list);
+	}
+	
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
@@ -1,0 +1,154 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * Stores the parameter configuration selected by the user and the default
+ * values.
+ */
+public class ParameterJsonHelper {
+
+	/** Simulation name */
+	private String simulationName;
+	/** length MemapSimulation steps. An integer */
+	@Expose
+	private int stepsPerDay;
+	/** steps MPC horizon. An integer */
+	@Expose
+	private int mpcHorizon;
+	/** days Number of days to be simulated */
+	@Expose
+	private int days;
+	/** optCriteria a String. Optimization criteria: {cost, co2} */
+	@Expose
+	private String optCriteria;
+	/** optimizer a String. Optimizer: {LP, MILP} */
+	@Expose
+	private String optimizer;
+	/** loggingMode a String. loggingMode: {allLogs, fileLogs, resultLogs} */
+	@Expose
+	private String loggingMode;
+	@Expose
+	private PriceJsonHelper elecSellingPrice;
+	@Expose
+	private PriceJsonHelper elecBuyingPrice;
+	@Expose
+	private PriceJsonHelper heatBuyingPrice;
+	@Expose
+	private PriceJsonHelper co2Emissions;
+
+	/**
+	 * Constructor for class Parameters
+	 */
+	public ParameterJsonHelper(int simulationSteps, int mpcHorizon, int days, String optCriteria,
+			String optimizer, String loggingMode, PriceJsonHelper elecBuyingPrice, PriceJsonHelper elecSellingPrice,
+			PriceJsonHelper heatBuyingPrice, PriceJsonHelper co2Emissions) {
+		setSimulationName("ImportFromMEMAPServer");
+		setStepsPerDay(simulationSteps);
+		this.mpcHorizon = mpcHorizon;
+		setDays(days);
+		setOptimizer(optimizer);
+		setOptCriteria(optCriteria);
+		setLoggingMode(loggingMode);
+		setElecBuyingPrice(elecBuyingPrice);
+		setElecSellingPrice(elecSellingPrice);
+		setHeatBuyingPrice(heatBuyingPrice);
+		setCO2Emissions(co2Emissions);
+	}
+
+	public String getSimulationName() {
+		return simulationName;
+	}
+
+	/**
+	 * Must be manually set after deserialization!
+	 */
+	public void setSimulationName(String simulationName) {
+		this.simulationName = simulationName;
+	}
+
+	public int getStepsPerDay() {
+		return stepsPerDay;
+	}
+
+	public void setStepsPerDay(int stepsPerDay) {
+		this.stepsPerDay = stepsPerDay;
+	}
+
+	public int getMPCHorizon() {
+		return mpcHorizon;
+	}
+
+//	public void setMPCHorizon(int mpcHorizon) {
+//		this.mpcHorizon = mpcHorizon;
+//		elecBuyingPrice.updateMPCHorizon(mpcHorizon);
+//		elecSellingPrice.updateMPCHorizon(mpcHorizon);
+//		heatBuyingPrice.updateMPCHorizon(mpcHorizon);
+//		setSaved(false);
+//	}
+
+	public int getDays() {
+		return days;
+	}
+
+	public void setDays(int days) {
+		this.days = days;
+	}
+
+	public String getOptimizer() {
+		return optimizer;
+	}
+
+	private void setOptimizer(String optimizer) {
+		this.optimizer = optimizer;
+	}
+
+	public String getOptCriteria() {
+		return optCriteria;
+	}
+
+	private void setOptCriteria(String optCriteria) {
+		this.optCriteria = optCriteria;
+	}
+
+	public String getLoggingMode() {
+		return loggingMode;
+	}
+
+	private void setLoggingMode(String loggingMode) {
+		this.loggingMode = loggingMode;
+	}
+
+	public PriceJsonHelper getElecSellingPrice() {
+		return elecSellingPrice;
+	}
+
+	public void setElecSellingPrice(PriceJsonHelper elecSellingPrice) {
+		this.elecSellingPrice = elecSellingPrice;
+	}
+
+	public PriceJsonHelper getElecBuyingPrice() {
+		return elecBuyingPrice;
+	}
+
+	public void setElecBuyingPrice(PriceJsonHelper elecBuyingPrice) {
+		this.elecBuyingPrice = elecBuyingPrice;
+	}
+
+	public PriceJsonHelper getHeatBuyingPrice() {
+		return heatBuyingPrice;
+	}
+
+	public void setHeatBuyingPrice(PriceJsonHelper heatBuyingPrice) {
+		this.heatBuyingPrice = heatBuyingPrice;
+	}
+	
+	public void setCO2Emissions(PriceJsonHelper co2Emissions) {
+		this.co2Emissions = co2Emissions;
+	}
+	
+	public PriceJsonHelper getCO2Emissions() {
+		return co2Emissions;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
@@ -37,9 +37,7 @@ public class ParameterJsonHelper {
 	@Expose
 	private PriceJsonHelper co2Emissions;
 
-	/**
-	 * Constructor for class Parameters
-	 */
+	
 	public ParameterJsonHelper(int simulationSteps, int mpcHorizon, int days, String optCriteria,
 			String optimizer, String loggingMode, PriceJsonHelper elecBuyingPrice, PriceJsonHelper elecSellingPrice,
 			PriceJsonHelper heatBuyingPrice, PriceJsonHelper co2Emissions) {
@@ -60,9 +58,6 @@ public class ParameterJsonHelper {
 		return simulationName;
 	}
 
-	/**
-	 * Must be manually set after deserialization!
-	 */
 	public void setSimulationName(String simulationName) {
 		this.simulationName = simulationName;
 	}
@@ -79,13 +74,9 @@ public class ParameterJsonHelper {
 		return mpcHorizon;
 	}
 
-//	public void setMPCHorizon(int mpcHorizon) {
-//		this.mpcHorizon = mpcHorizon;
-//		elecBuyingPrice.updateMPCHorizon(mpcHorizon);
-//		elecSellingPrice.updateMPCHorizon(mpcHorizon);
-//		heatBuyingPrice.updateMPCHorizon(mpcHorizon);
-//		setSaved(false);
-//	}
+	public void setMPCHorizon(int mpcHorizon) {
+		this.mpcHorizon = mpcHorizon;
+	}
 
 	public int getDays() {
 		return days;

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/PriceJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/PriceJsonHelper.java
@@ -1,0 +1,34 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+public class PriceJsonHelper {
+	@Expose
+	private boolean fixed;
+	@Expose
+	private double price;
+	@Expose
+	private String priceFilePath;
+
+	public PriceJsonHelper(boolean fixed, double price, String priceFilePath, int mpcHorizon) {
+		setFixed(fixed);
+		setPrice(price, mpcHorizon);
+		setPriceFilePath(priceFilePath);
+	}
+
+	public boolean isFixed() {
+		return fixed;
+	}
+
+	public void setFixed(boolean fixed) {
+		this.fixed = fixed;
+	}
+	
+	public void setPrice(double price, int mpcHorizon) {
+		this.price = price;
+	}
+
+	public void setPriceFilePath(String priceFilePath) {
+		this.priceFilePath = priceFilePath;
+	}
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ProducerJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ProducerJsonHelper.java
@@ -1,0 +1,105 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.ProducerMessage;
+
+/**
+ * Controllable is the class for representing controllable Producer objects.
+ * Example: Gas Boiler
+ */
+public class ProducerJsonHelper{
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkType; // Values: Heat or Electricity
+	@Expose
+	private double minimumPower;
+	@Expose
+	private double maximumPower;
+	@Expose
+	private double efficiency;
+	@Expose
+	private double cost;
+	@Expose
+	private double coEmission;
+
+	/**
+	 * Constructor for class Controllable
+	 * 
+	 * @param name        an alphanumeric string
+	 * @param networkType a string: Heat or Electricity
+	 * @param minimumPower        a positive double [kW]
+	 * @param maximumPower        a positive double [kW]
+	 * @param efficiency  a positive double
+	 * @param cost        a positive double [EUR]
+	 * @param coEmission  CO2 Emissions measured in [g/kWh]
+	 */
+	public ProducerJsonHelper(ProducerMessage producerMessage) {
+		
+		setName(producerMessage.name);
+		setNetworkType(producerMessage.networkType);
+		setMinimumPower(producerMessage.minPower);
+		setMaximumPower(producerMessage.maxPower);
+		setEfficiency(producerMessage.efficiency);
+		setCost(producerMessage.operationalCostEUR);
+		setCOEmission(producerMessage.operationalCostCO2);
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getNetworkType() {
+		return networkType;
+	}
+
+	public void setNetworkType(NetworkType networkType) {
+		this.networkType = networkType.toString();
+	}
+
+	public double getMinimumPower() {
+		return minimumPower;
+	}
+
+	public void setMinimumPower(double minimumPower) {
+		this.minimumPower = minimumPower;
+	}
+	
+	public double getMaximumPower() {
+		return maximumPower;
+	}
+
+	public void setMaximumPower(double maximumPower) {
+		this.maximumPower = maximumPower;
+	}
+
+	public double getEfficiency() {
+		return efficiency;
+	}
+
+	public void setEfficiency(double efficiency) {
+		this.efficiency = efficiency;
+	}
+
+	public double getCost() {
+		return cost;
+	}
+
+	public void setCost(double cost) {
+		this.cost = cost;
+	}
+
+	public double getCOEmission() {
+		return coEmission;
+	}
+
+	public void setCOEmission(double coEmission) {
+		this.coEmission = coEmission;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/StorageJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/StorageJsonHelper.java
@@ -1,0 +1,130 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.StorageMessage;
+
+/**
+ * Storage is the class for representing Storage objects. Example: Battery,
+ * ThermalStorage.
+ */
+public class StorageJsonHelper {
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkType;
+	@Expose
+	private double capacity;
+	@Expose
+	private double soc;
+	@Expose
+	private double losses;
+	@Expose
+	private double maxCharging;
+	@Expose
+	private double maxDischarging;
+	@Expose
+	private double effIN;
+	@Expose
+	private double effOUT;
+
+	/**
+	 * Constructor for class Storage
+	 * 
+	 * @param name           an alphanumeric string
+	 * @param networkType    a string: Heat or Electricity
+	 * @param capacity       a positive double
+	 * @param soc            state of charge
+	 * @param losses         losses [%/h]. Percentage is in [0, 1]
+	 * @param maxCharging    maximum charging rate. A positive double
+	 * @param maxDischarging maximum discharging rate. A positive double
+	 * @param effIN          charging efficiency. A positive double
+	 * @param effOUT         discharging efficiency. A positive double
+	 */
+	public StorageJsonHelper(StorageMessage storageMessage) {
+		setName(storageMessage.name);
+		setNetworkType(storageMessage.networkType);
+		setCapacity(storageMessage.capacity);
+		setSoc(storageMessage.stateOfCharge);
+		setLosses(storageMessage.storageLosses);
+		setMaxCharging(storageMessage.maxLoad);
+		setMaxDischarging(storageMessage.maxDischarge);
+		setEffIN(storageMessage.efficiencyCharge);
+		setEffOUT(storageMessage.efficiencyDischarge);
+	}
+	
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getNetworkType() {
+		return networkType;
+	}
+
+	public void setNetworkType(NetworkType networkType) {
+		this.networkType = networkType.toString();
+	}
+
+	public double getCapacity() {
+		return capacity;
+	}
+
+	public void setCapacity(double capacity) {
+		this.capacity = capacity;
+	}
+
+	public double getSoc() {
+		return soc;
+	}
+
+	public void setSoc(double soc) {
+		this.soc = soc;
+	}
+
+	public double getLosses() {
+		return losses;
+	}
+
+	public void setLosses(double losses) {
+		// TODO, we might add units for losses in future. We should assure that it is written here correctly.
+		this.losses = losses;
+	}
+
+	public double getMaxCharging() {
+		return maxCharging;
+	}
+
+	public void setMaxCharging(double maxCharging) {
+		this.maxCharging = maxCharging;
+	}
+
+	public double getMaxDischarging() {
+		return maxDischarging;
+	}
+
+	public void setMaxDischarging(double maxDischargeRate) {
+		this.maxDischarging = maxDischargeRate;
+	}
+
+	public double getEffIN() {
+		return effIN;
+	}
+
+	public void setEffIN(double efficiencyCharge) {
+		this.effIN = efficiencyCharge;
+	}
+
+	public double getEffOUT() {
+		return effOUT;
+	}
+
+	public void setEffOUT(double efficiencyDischarge) {
+		this.effOUT = efficiencyDischarge;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/VolatileJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/VolatileJsonHelper.java
@@ -1,0 +1,105 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.ProducerMessage;
+
+/**
+ * Volatile is the class for representing volatile Producer objects. Example:
+ * PV, SolarThermic
+ */
+public class VolatileJsonHelper {
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkType; // Values: Heat or Electricity
+	@Expose
+	private double minimumPower;
+	@Expose
+	private double maximumPower;
+	@Expose
+	private String forecastFile;
+	@Expose
+	private double cost;
+	@Expose
+	private double coEmission;
+
+
+	/**
+	 * Constructor for class Volatile
+	 * 
+	 * @param name         an alphanumeric string
+	 * @param networkType  a string: Heat or Electricity
+	 * @param minimumPower a positive double [kW]
+	 * @param maximumPower a positive double [kW]
+	 * @param forecastFile a path to an existing file
+	 * @param cost         a positive double [EUR]
+	 * @param coEmission   CO2 Emissions measured in [g/kWh]
+	 */
+	public VolatileJsonHelper(ProducerMessage producerMessage) {
+
+		setName(producerMessage.name);
+		setNetworkType(producerMessage.networkType);
+		setMinimumPower(producerMessage.minPower);
+		setMaximumPower(producerMessage.maxPower);
+		setCost(producerMessage.operationalCostEUR);
+		setCOEmission(producerMessage.operationalCostCO2);
+		}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getNetworkType() {
+		return networkType;
+	}
+
+	public void setNetworkType(NetworkType networkType) {
+		this.networkType = networkType.toString();
+	}
+
+	public double getMinimumPower() {
+		return minimumPower;
+	}
+
+	public void setMinimumPower(double minimumPower) {
+		this.minimumPower = minimumPower;
+	}
+
+	public double getMaximumPower() {
+		return maximumPower;
+	}
+
+	public void setMaximumPower(double maximumPower) {
+		this.maximumPower = maximumPower;
+	}
+
+	public String getForecastFile() {
+		return forecastFile;
+	}
+
+	public void setForecastFile(String forecastFile) {
+		this.forecastFile = forecastFile;
+	}
+
+	public double getCost() {
+		return cost;
+	}
+
+	public void setCost(double cost) {
+		this.cost = cost;
+	}
+
+	public double getCOEmission() {
+		return coEmission;
+	}
+
+	public void setCOEmission(double coEmission) {
+		this.coEmission = coEmission;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helperOPCua/OpcServerContextGenerator.java
+++ b/projects/memapCore/src/main/java/memap/helperOPCua/OpcServerContextGenerator.java
@@ -4,10 +4,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-
+import java.util.ArrayList;
 import com.google.gson.Gson;
 
-import akka.basicMessages.AnswerContent;
 import helper.IoHelper;
 import memap.helper.DirectoryConfiguration;
 
@@ -15,11 +14,12 @@ public class OpcServerContextGenerator {
 
 	public static Gson gson = new Gson();
 
-	public static void generateJson(String actorName, AnswerContent content) {
-		String result = gson.toJson(content);
+	public static void generateJson(String actorName, ArrayList<Object> list) {
+		String result = gson.toJson(list);
 		writeFile(actorName, result);
 	}
 
+	
 	// TODO adapt the output folder
 	private static void writeFile(String filename, String result) {
 		String source = "/" + DirectoryConfiguration.mainDir + "/" + DirectoryConfiguration.configDir + "/" + filename

--- a/projects/memapCore/src/main/java/memap/main/JettyStart.java
+++ b/projects/memapCore/src/main/java/memap/main/JettyStart.java
@@ -72,13 +72,23 @@ public class JettyStart {
 
 	public void run(JsonObject memapStartMessage) {
 
-		topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILPwithConnections,
-				OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.ALL);
+		topologyMemapOn = new TopologyController(
+				"MemapOn", 
+				OptHierarchy.MEMAP, 
+				Optimizer.MILPwithConnections,
+				OptimizationCriteria.EUR, 
+				ToolUsage.SERVER, 
+				MEMAPLogging.ALL
+				);
 
 		TopologyConfig.getInstance().init(Simulation.N_STEPS_MPC, 96, 30, 7020, 0);
 		System.out.println(">> MPC set to " + Simulation.N_STEPS_MPC);
-		EnergyPrices.getInstance().init(new ElectricityPrice(0.285, Simulation.N_STEPS_MPC),
-				new ElectricityPrice(0.285, Simulation.N_STEPS_MPC), new HeatPrice(0.285, Simulation.N_STEPS_MPC));
+		
+		EnergyPrices.getInstance().init(
+				new ElectricityPrice(0.285, Simulation.N_STEPS_MPC), //global buying price
+				new ElectricityPrice(0.08, Simulation.N_STEPS_MPC),  //global selling price
+				new HeatPrice(0.13, Simulation.N_STEPS_MPC) 		 //global heat price
+				);
 
 		if (doubleSim) {
 			topologyMemapOff = new TopologyController("MemapOff", OptHierarchy.BUILDING, Optimizer.MILP,


### PR DESCRIPTION
In plattform version, now a JSON is generated after first simulation loop, containing all the building and device information from the answerContent/buildingMessages.

The JSON is formatted according to calsses from memapGui, which were copied to memapCore/.../helpers/ as "JsonHelpers" for this purpose. The resulting structure is the same as JSONs saved by the planning tool and can thus be imported for further simulations.

A generated JSON(from the two CoSES opcua Servers) is attached. 
_I had to rename it so you have to change the ending back to .json._

[MemapOn_forPlanningTool.txt](https://github.com/SES-fortiss/SmartGridCoSimulation/files/6672091/MemapOn_forPlanningTool.txt)


**Only remark:** There is an error with this JSON when loading the simulation Parameters (click on run simulation). This is because of different naming in memapCore and memapGui (e.g. EUR/CO vs. cost/co2). Maybe this can be unified at some point.
 