### PR TITLE
connections and topology defined through new Json key

### DIFF
--- a/projects/memapCore/src/main/java/memap/components/ClientEMS.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientEMS.java
@@ -6,6 +6,8 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 
+import com.github.cliftonlabs.json_simple.JsonObject;
+
 import akka.basicMessages.AnswerContent;
 import memap.components.prototypes.Connection;
 import memap.controller.TopologyController;
@@ -34,12 +36,25 @@ public class ClientEMS extends Connection {
 	public NodeId connEffId;
 	public double trigger;
 	
-	public ClientEMS(BasicClient client, TopologyController topologyController, String name, String connFrom, String connTo, NodeId triggerId, NodeId connEffId, int port) throws InterruptedException, ExecutionException {
-		super(connFrom, connTo, 50, client.readFinalDoubleValue(connEffId), 999);
+	// Constructor with Connection
+	public ClientEMS(BasicClient client, TopologyController topologyController, String name, NodeId triggerId, String connFrom, String connTo, double connLength, double connLosses, double q_max, int port) throws InterruptedException, ExecutionException {
+		super(connFrom, connTo, connLength, connLosses, q_max);
+
 		this.client = client;
 		this.topologyController = topologyController;
 		this.triggerId = triggerId; 
 	}
+
+	// Constructor without Connection
+	public ClientEMS(BasicClient client, TopologyController topologyController, String name, NodeId triggerId,
+			int port) {
+		super("None", "None", 0, 0, 0);
+
+		this.client = client;
+		this.topologyController = topologyController;
+		this.triggerId = triggerId; 
+	}
+
 
 	@Override
 	public void makeDecision() {
@@ -54,8 +69,7 @@ public class ClientEMS extends Connection {
 			connectionMessage.connectedBuildingTo = connectedBuilding;
 			
 			connectionMessage.efficiency = efficiency;
-			connectionMessage.maxPower = 0.0; //q_max;
-			// TODO: efficiency = 0 seems to not prevent heat transfer
+			connectionMessage.maxPower = q_max;
 			connectionMessage.pipeLengthInMeter = pipeLengthInMeter;
 			connectionMessage.operationalCostEUR = 0.0001;
 			connectionMessage.operationalCostCO2 = 0.0001;

--- a/projects/memapCore/src/main/java/memap/components/ClientEMS.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientEMS.java
@@ -6,15 +6,10 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 
-import com.github.cliftonlabs.json_simple.JsonObject;
-
 import akka.basicMessages.AnswerContent;
-import memap.components.prototypes.Connection;
+import memap.components.prototypes.Device;
 import memap.controller.TopologyController;
-import memap.helper.configurationOptions.Optimizer;
 import memap.helperOPCua.BasicClient;
-import memap.messages.extension.NetworkType;
-import memap.messages.planning.ConnectionMessage;
 
 
 /**
@@ -24,12 +19,10 @@ import memap.messages.planning.ConnectionMessage;
  * @param port
  */
 
-public class ClientEMS extends Connection {
+public class ClientEMS extends Device {
 	
 	/** Reference to the topology */
 	protected TopologyController topologyController;
-	
-	public ConnectionMessage connectionMessage = new ConnectionMessage();
 	
 	public BasicClient client;
 	public NodeId triggerId;
@@ -37,48 +30,10 @@ public class ClientEMS extends Connection {
 	public double trigger;
 	
 	// Constructor with Connection
-	public ClientEMS(BasicClient client, TopologyController topologyController, String name, NodeId triggerId, String connFrom, String connTo, double connLength, double connLosses, double q_max, int port) throws InterruptedException, ExecutionException {
-		super(connFrom, connTo, connLength, connLosses, q_max);
-
+	public ClientEMS (BasicClient client, String name, NodeId triggerId, int port) throws InterruptedException, ExecutionException {
+		super(name, port);
 		this.client = client;
-		this.topologyController = topologyController;
 		this.triggerId = triggerId; 
-	}
-
-	// Constructor without Connection
-	public ClientEMS(BasicClient client, TopologyController topologyController, String name, NodeId triggerId,
-			int port) {
-		super("None", "None", 0, 0, 0);
-
-		this.client = client;
-		this.topologyController = topologyController;
-		this.triggerId = triggerId; 
-	}
-
-
-	@Override
-	public void makeDecision() {
-		if (topologyController.getOptimizer() == Optimizer.MILPwithConnections) {
-					
-			connectionMessage.networkType = NetworkType.HEAT;
-			
-			connectionMessage.name = actorName;
-			connectionMessage.id = fullActorPath;
-			
-			connectionMessage.connectedBuildingFrom = sourceBuilding;
-			connectionMessage.connectedBuildingTo = connectedBuilding;
-			
-			connectionMessage.efficiency = efficiency;
-			connectionMessage.maxPower = q_max;
-			connectionMessage.pipeLengthInMeter = pipeLengthInMeter;
-			connectionMessage.operationalCostEUR = 0.0001;
-			connectionMessage.operationalCostCO2 = 0.0001;
-		}
-	}
-
-	@Override
-	public AnswerContent returnAnswerContentToSend() {
-		return connectionMessage;
 	}
 	
 	@Override
@@ -98,8 +53,13 @@ public class ClientEMS extends Connection {
 			client.writeValue(triggerId, newTrigger);
 			
 			System.out.println("Trigger written: " + trigger);
-
 		}
+	}
+
+	@Override
+	public AnswerContent returnAnswerContentToSend() {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/projects/memapCore/src/main/java/memap/components/ClientEMSconnection.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientEMSconnection.java
@@ -1,0 +1,91 @@
+package memap.components;
+
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+
+import akka.basicMessages.AnswerContent;
+import memap.components.prototypes.Connection;
+import memap.controller.TopologyController;
+import memap.helper.configurationOptions.Optimizer;
+import memap.helperOPCua.BasicClient;
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.ConnectionMessage;
+
+
+/**
+ * @param client
+ * @param name              EMS name
+ * @param trigger			triggers EMS to update Setpoints
+ * @param port
+ */
+
+public class ClientEMSconnection extends Connection {
+	
+	/** Reference to the topology */
+	protected TopologyController topologyController;
+	
+	public ConnectionMessage connectionMessage = new ConnectionMessage();
+	
+	public BasicClient client;
+	public NodeId triggerId;
+	public NodeId connEffId;
+	public double trigger;
+	
+	// Constructor with Connection
+	public ClientEMSconnection(BasicClient client, TopologyController topologyController, String name, NodeId triggerId, String connFrom, String connTo, double connLength, double connLosses, double q_max, int port) throws InterruptedException, ExecutionException {
+		super(connFrom, connTo, connLength, connLosses, q_max);
+
+		this.client = client;
+		this.topologyController = topologyController;
+		this.triggerId = triggerId; 
+	}
+
+	@Override
+	public void makeDecision() {
+		if (topologyController.getOptimizer() == Optimizer.MILPwithConnections) {
+					
+			connectionMessage.networkType = NetworkType.HEAT;
+			
+			connectionMessage.name = actorName;
+			connectionMessage.id = fullActorPath;
+			
+			connectionMessage.connectedBuildingFrom = sourceBuilding;
+			connectionMessage.connectedBuildingTo = connectedBuilding;
+			
+			connectionMessage.efficiency = efficiency;
+			connectionMessage.maxPower = q_max;
+			connectionMessage.pipeLengthInMeter = pipeLengthInMeter;
+			connectionMessage.operationalCostEUR = 0.0001;
+			connectionMessage.operationalCostCO2 = 0.0001;
+		}
+	}
+
+	@Override
+	public AnswerContent returnAnswerContentToSend() {
+		return connectionMessage;
+	}
+	
+	@Override
+	public void handleRequest() {
+		
+		if (triggerId != null) {
+			try {
+				this.trigger = client.readFinalDoubleValue(triggerId);
+			} catch (InterruptedException | ExecutionException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			}
+			
+			// CoSES: Trigger should be increased only once
+			trigger++;
+			DataValue newTrigger = new DataValue(new Variant(trigger), null, null);
+			client.writeValue(triggerId, newTrigger);
+			
+			System.out.println("Trigger written: " + trigger);
+		}
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/components/ClientEMSconnection.java
+++ b/projects/memapCore/src/main/java/memap/components/ClientEMSconnection.java
@@ -33,6 +33,7 @@ public class ClientEMSconnection extends Connection {
 	public NodeId triggerId;
 	public NodeId connEffId;
 	public double trigger;
+	public double connLosses;
 	
 	// Constructor with Connection
 	public ClientEMSconnection(BasicClient client, TopologyController topologyController, String name, NodeId triggerId, String connFrom, String connTo, double connLength, double connLosses, double q_max, int port) throws InterruptedException, ExecutionException {
@@ -41,6 +42,7 @@ public class ClientEMSconnection extends Connection {
 		this.client = client;
 		this.topologyController = topologyController;
 		this.triggerId = triggerId; 
+		this.connLosses = connLosses;
 	}
 
 	@Override
@@ -55,9 +57,10 @@ public class ClientEMSconnection extends Connection {
 			connectionMessage.connectedBuildingFrom = sourceBuilding;
 			connectionMessage.connectedBuildingTo = connectedBuilding;
 			
-			connectionMessage.efficiency = efficiency;
 			connectionMessage.maxPower = q_max;
 			connectionMessage.pipeLengthInMeter = pipeLengthInMeter;
+			connectionMessage.losses = connLosses;
+			connectionMessage.efficiency = efficiency;
 			connectionMessage.operationalCostEUR = 0.0001;
 			connectionMessage.operationalCostCO2 = 0.0001;
 		}

--- a/projects/memapCore/src/main/java/memap/components/prototypes/MEMAPCoordination.java
+++ b/projects/memapCore/src/main/java/memap/components/prototypes/MEMAPCoordination.java
@@ -1,6 +1,8 @@
 package memap.components.prototypes;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.google.gson.Gson;
 
@@ -12,17 +14,31 @@ import behavior.BehaviorModel;
 import lpsolve.LpSolveException;
 import memap.controller.TopologyController;
 import memap.helper.SolutionHandler;
+import memap.helper.JsonExportHelper.BuildingJsonHelper;
+import memap.helper.JsonExportHelper.CouplerJsonHelper;
+import memap.helper.JsonExportHelper.DemandJsonHelper;
+import memap.helper.JsonExportHelper.ParameterJsonHelper;
+import memap.helper.JsonExportHelper.PriceJsonHelper;
+import memap.helper.JsonExportHelper.ProducerJsonHelper;
+import memap.helper.JsonExportHelper.StorageJsonHelper;
+import memap.helper.JsonExportHelper.VolatileJsonHelper;
 import memap.helper.configurationOptions.OptHierarchy;
 import memap.helper.configurationOptions.Optimizer;
 import memap.helper.configurationOptions.ToolUsage;
 import memap.helper.lp.LPSolver;
 import memap.helper.milp.MILPSolverNoConnections;
 import memap.helper.milp.MILPSolverWithConnections;
+import memap.helperOPCua.OpcServerContextGenerator;
+import memap.main.Simulation;
 import memap.main.TopologyConfig;
 import memap.messages.BuildingMessage;
 import memap.messages.BuildingMessageHandler;
 import memap.messages.OptimizationResultMessage;
 import memap.messages.extension.ChildSpecification;
+import memap.messages.planning.CouplerMessage;
+import memap.messages.planning.DemandMessage;
+import memap.messages.planning.ProducerMessage;
+import memap.messages.planning.StorageMessage;
 import opcMEMAP.MemapOpcServerStarter;
 /**
  * This model optimizes over several buildings for the planning tool.
@@ -170,6 +186,69 @@ public class MEMAPCoordination extends BehaviorModel implements CurrentTimeStepS
 					e.printStackTrace();
 				}
 			}
+			
+			
+			// Option to save topology as json for usage in planning tool:
+			if (true) {			
+				if (currentTimeStep == 0) { 
+					ArrayList<Object> list = new ArrayList<Object>();
+					Set<BuildingJsonHelper> buildingSet = new HashSet<BuildingJsonHelper>();
+					BuildingJsonHelper bjh = null;
+					
+					for (BasicAnswer basicAnswer : answerListReceived) {
+						AnswerContent answerContent = basicAnswer.answerContent;
+						if (answerContent instanceof BuildingMessage) {
+							BuildingMessage bmsg = (BuildingMessage) answerContent;
+												
+							bjh = new BuildingJsonHelper(bmsg);
+							
+							for (DemandMessage dm : bmsg.demandList) {
+								DemandJsonHelper djh = new DemandJsonHelper(dm);
+								bjh.addDemand(djh);
+							}
+							for (CouplerMessage cm : bmsg.couplerList) {
+								CouplerJsonHelper cjh = new CouplerJsonHelper(cm);
+								bjh.addCoupler(cjh);
+							}
+							for (ProducerMessage pm : bmsg.controllableProducerList) {
+								ProducerJsonHelper pjh = new ProducerJsonHelper(pm);
+								bjh.addContProduction(pjh);
+							}
+							for (ProducerMessage vpm : bmsg.volatileProducerList) {
+								VolatileJsonHelper vjh = new VolatileJsonHelper(vpm);
+								bjh.addVolProduction(vjh);
+							}
+							for (StorageMessage sm : bmsg.storageList) {
+								StorageJsonHelper sjh = new StorageJsonHelper(sm);
+								bjh.addStorage(sjh);
+							}
+						}
+					buildingSet.add(bjh);
+					}
+					list.add(buildingSet);
+					
+					Set<Object> connections = new HashSet<Object>();
+					list.add(connections);
+					
+					Set<ParameterJsonHelper> parameterSet = new HashSet<ParameterJsonHelper>();
+					ParameterJsonHelper paramjh = new ParameterJsonHelper(
+							96,
+							Simulation.N_STEPS_MPC,
+							2,
+							topologyController.getOptimizationCriteria().toString(),
+							topologyController.getOptimizer().toString(),
+							topologyController.getLogging().toString(),
+							new PriceJsonHelper(true, 0.3, "", Simulation.N_STEPS_MPC),   // elecBuyingPrice
+							new PriceJsonHelper(true, 0.08, "", Simulation.N_STEPS_MPC),  // elecSellingPrice
+							new PriceJsonHelper(true, 0.13, "", Simulation.N_STEPS_MPC),  // heatBuyingPrice
+							new PriceJsonHelper(true, 0.404, "", Simulation.N_STEPS_MPC)  // co2Emissions
+							);
+					parameterSet.add(paramjh);
+					list.add(parameterSet);
+					// gson.toJson(list, new FileWriter("PATH\\OutputForPlanningTool.json"));
+					OpcServerContextGenerator.generateJson(this.actorName + "_forPlanningTool", list);
+				}
+			}		
 		}
 		
 		return buildingMessage;

--- a/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
+++ b/projects/memapCore/src/main/java/memap/controller/OpcUaBuildingController.java
@@ -16,9 +16,9 @@ import com.google.gson.Gson;
 
 import memap.components.prototypes.Device;
 import memap.helper.HelperUnnestingJSON;
-import memap.helper.configurationOptions.Optimizer;
 import memap.components.ClientDemand;
 import memap.components.ClientEMS;
+import memap.components.ClientEMSconnection;
 import memap.components.ClientCoupler;
 import memap.components.ClientProducer;
 import memap.components.ClientStorage;
@@ -252,15 +252,16 @@ public class OpcUaBuildingController implements BuildingController {
 								double q_max = ((Number) connectionConfig.get("maxTransportCapacity")).doubleValue();
 								System.out.println("Connection is considered from " + sourceBuilding + " to " + connectedBuilding);
 							
-								ClientEMS ems = new ClientEMS(client, topologyController, name, triggerId, sourceBuilding, connectedBuilding, pipeLengthInMeter, lossesPer100m, q_max, 0);
+								ClientEMSconnection ems = new ClientEMSconnection(client, topologyController, name, triggerId, sourceBuilding, connectedBuilding, pipeLengthInMeter, lossesPer100m, q_max, 0);
 								attach(ems);
 								ems.setTopologyController(topologyController);
 			
 							} else {
-								ClientEMS ems = new ClientEMS(client, topologyController, name, triggerId, 0);
+								
+								ClientEMS ems = new ClientEMS(client, name, triggerId, 0);
 								attach(ems);
+								ems.setTopologyController(topologyController);
 							}
-							
 							
 							System.out.println("EMS (" + EMSkey + ") added. ");
 							} catch (Exception e) {

--- a/projects/memapCore/src/main/java/memap/examples/ExampleLoader.java
+++ b/projects/memapCore/src/main/java/memap/examples/ExampleLoader.java
@@ -52,7 +52,7 @@ public abstract class ExampleLoader {
 			JsonObject jsonEndpoint1 = (JsonObject) Jsoner.deserialize(endpoint1);
 			JsonObject jsonNodes1 = (JsonObject) Jsoner.deserialize(nodes1);
 			BuildingController sampleBuilding1 = new OpcUaBuildingController(topologyController, jsonEndpoint1,
-					jsonNodes1);
+					jsonNodes1, null);
 			topologyController.attach(sampleBuilding1.getName(), sampleBuilding1);
 
 		} catch (JsonException e1) {
@@ -78,7 +78,7 @@ public abstract class ExampleLoader {
 			JsonObject jsonEndpoint2 = (JsonObject) Jsoner.deserialize(endpoint2);
 			JsonObject jsonNodes2 = (JsonObject) Jsoner.deserialize(nodes2);
 			BuildingController sampleBuilding2 = new OpcUaBuildingController(topologyController, jsonEndpoint2,
-					jsonNodes2);
+					jsonNodes2, null);
 			topologyController.attach(sampleBuilding2.getName(), sampleBuilding2);
 		} catch (JsonException e1) {
 			System.err.println("WARNING: Failed to read JSON config files. Building has not been initalised.");

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
@@ -1,0 +1,34 @@
+package memap.helper.JsonExportHelper;
+
+import java.awt.geom.Point2D;
+
+import com.google.gson.annotations.Expose;
+
+public class BuildingIconJsonHelper {
+
+	@Expose
+	private Point2D position;
+	
+	public BuildingIconJsonHelper(int i) {
+		
+		Point2D defaultposition = new Point2D.Double(391 + 5*i, 206 + 5*i);
+		
+		setPosition(defaultposition);		
+	}
+	
+	/**
+	 * @return the position
+	 */
+	public Point2D getPosition() {
+		return position;
+	}
+
+	/**
+	 * @param position the position to set
+	 */
+	public void setPosition(Point2D position) {
+		this.position = position;
+	}
+	
+	
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingIconJsonHelper.java
@@ -9,23 +9,15 @@ public class BuildingIconJsonHelper {
 	@Expose
 	private Point2D position;
 	
-	public BuildingIconJsonHelper(int i) {
-		
+	public BuildingIconJsonHelper(int i) {	
 		Point2D defaultposition = new Point2D.Double(391 + 5*i, 206 + 5*i);
-		
 		setPosition(defaultposition);		
 	}
 	
-	/**
-	 * @return the position
-	 */
 	public Point2D getPosition() {
 		return position;
 	}
 
-	/**
-	 * @param position the position to set
-	 */
 	public void setPosition(Point2D position) {
 		this.position = position;
 	}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
@@ -28,24 +28,15 @@ public class BuildingJsonHelper {
 	private ArrayList<VolatileJsonHelper> volatile_list = new ArrayList<VolatileJsonHelper>();
 	@Expose
 	private ArrayList<StorageJsonHelper> storage_list = new ArrayList<StorageJsonHelper>();
-
 	@Expose
 	private BuildingIconJsonHelper icon = new BuildingIconJsonHelper(0);
 
-//	/**
-//	 * Constructor for class Building
-//	 * 
-//	 * @param name an alphanumeric string
-//	 * @param port an integer between 1024 and 49151, or 0
-//	 * 
-//	 */
+	
 	public BuildingJsonHelper(BuildingMessage buildingMessage) {
-		// Do not use setName() in the constructor!
 
 		this.name = buildingMessage.name;
 		setFormattedName(name);
 		this.setPort(port);
-
 	}
 
 	public String getName() {
@@ -75,18 +66,6 @@ public class BuildingJsonHelper {
 		this.port = port;
 	}
 
-	
-	
-//	public ArrayList<Device> getComponents(){
-//		ArrayList<Device> components = new ArrayList<Device>();
-//		components.addAll(demand_list);
-//		components.addAll(storage_list);
-//		components.addAll(volatile_list);
-//		components.addAll(controllable_list);
-//		components.addAll(coupler_list);
-//		return components;
-//	}
-
 	public void addCoupler(CouplerJsonHelper coupler) {
 		coupler_list.add(coupler);
 	}
@@ -106,6 +85,5 @@ public class BuildingJsonHelper {
 	public void addDemand(DemandJsonHelper demand) {
 		demand_list.add(demand);
 	}
-
 
 }

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/BuildingJsonHelper.java
@@ -1,0 +1,111 @@
+package memap.helper.JsonExportHelper;
+
+import java.util.ArrayList;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.BuildingMessage;
+
+/**
+ * Building is the class for representing Energy Management Systems (EMS).
+ */
+public class BuildingJsonHelper {
+	
+	@Expose
+	private String name;
+	@Expose
+	protected String formattedName;
+	@Expose
+	private int port;
+
+	@Expose
+	private ArrayList<DemandJsonHelper> demand_list = new ArrayList<DemandJsonHelper>();
+	@Expose
+	private ArrayList<CouplerJsonHelper> coupler_list = new ArrayList<CouplerJsonHelper>();
+	@Expose
+	private ArrayList<ProducerJsonHelper> controllable_list = new ArrayList<ProducerJsonHelper>();
+	@Expose
+	private ArrayList<VolatileJsonHelper> volatile_list = new ArrayList<VolatileJsonHelper>();
+	@Expose
+	private ArrayList<StorageJsonHelper> storage_list = new ArrayList<StorageJsonHelper>();
+
+	@Expose
+	private BuildingIconJsonHelper icon = new BuildingIconJsonHelper(0);
+
+//	/**
+//	 * Constructor for class Building
+//	 * 
+//	 * @param name an alphanumeric string
+//	 * @param port an integer between 1024 and 49151, or 0
+//	 * 
+//	 */
+	public BuildingJsonHelper(BuildingMessage buildingMessage) {
+		// Do not use setName() in the constructor!
+
+		this.name = buildingMessage.name;
+		setFormattedName(name);
+		this.setPort(port);
+
+	}
+
+	public String getName() {
+		return name;
+	}
+	
+	public String getFormattedName() {		
+		if (formattedName == null) return name;		
+		return formattedName;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+		setFormattedName(name);
+	}
+	
+	public void setFormattedName(String name) {
+		this.formattedName = name.replace("Ä", "Ae").replace("Ö", "Oe").replace("Ü", "Ue").replace("ä", "ae")
+				.replace("ö", "oe").replace("ü", "ue").replace("ß", "ss");
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	
+	
+//	public ArrayList<Device> getComponents(){
+//		ArrayList<Device> components = new ArrayList<Device>();
+//		components.addAll(demand_list);
+//		components.addAll(storage_list);
+//		components.addAll(volatile_list);
+//		components.addAll(controllable_list);
+//		components.addAll(coupler_list);
+//		return components;
+//	}
+
+	public void addCoupler(CouplerJsonHelper coupler) {
+		coupler_list.add(coupler);
+	}
+
+	public void addContProduction(ProducerJsonHelper cont_production) {
+		controllable_list.add(cont_production);
+	}
+
+	public void addVolProduction(VolatileJsonHelper vol_production) {
+		volatile_list.add(vol_production);
+	}
+
+	public void addStorage(StorageJsonHelper storage) {
+		storage_list.add(storage);
+	}
+	
+	public void addDemand(DemandJsonHelper demand) {
+		demand_list.add(demand);
+	}
+
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ConnectionJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ConnectionJsonHelper.java
@@ -1,0 +1,139 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+import memap.messages.planning.ConnectionMessage;
+
+/**
+ * Represents the connection between two labels and its characteristics.
+ */
+public class ConnectionJsonHelper {
+
+	/** Name of the node A. For serialization purposes ~ MEMAP gui */
+	@Expose
+	private String nameNodeA;
+	/** Formatted name of the node A. For serialization purposes ~ MEMAP core */
+	@Expose
+	private String formattedNameNodeA;
+	/** Name of the node B. For serialization purposes */
+	@Expose
+	private String nameNodeB;
+	/** Formatted name of the node B. For serialization purposes ~ MEMAP core */
+	@Expose
+	private String formattedNameNodeB;
+
+//	/** A color to draw the line (ln) */
+//	private Color color;
+//	/** Reference to an existing building label */
+//	private BuildingIcon nodeA;
+//	/** Reference to an existing building label */
+//	private BuildingIcon nodeB;
+//	/** Default length of connection */
+//	private static final double DEFAULT_LENGTH = 10.0;
+//	/** Default looses value of connection */
+//	private static final double DEFAULT_LOSSES = 10;
+//	/** Default transport capacity of connection */
+//	private static final double DEFAULT_TRANSPORT_CAPACITY = 999;
+//	/** Line between nodeA and nodeB */
+//	private Line2D ln;
+//	/** Length of connection [m] */
+	@Expose
+	private double length;
+	/** Looses of connection [%] */
+	@Expose
+	private double losses;
+	/** Maximum transport capacity [kW] */
+	@Expose
+	private double maxTransportCapacity;
+
+
+	public ConnectionJsonHelper(ConnectionMessage connectionMessage) {
+		setNameNodeA(connectionMessage.connectedBuildingFrom);
+		setFormattedNameNodeA(nameNodeA);
+		setNameNodeB(connectionMessage.connectedBuildingTo);
+		setFormattedNameNodeB(nameNodeB);
+//		setColor();
+//		setLn();
+		setLength(connectionMessage.pipeLengthInMeter);
+		setLosses(connectionMessage.losses);
+		setMaxTransportCapacity(connectionMessage.maxPower);
+	}
+
+	public double getLength() {
+		return length;
+	}
+
+	public void setLength(double length) {
+		this.length = length;
+	}
+
+	public double getLosses() {
+		return losses * 100;
+	}
+
+	public void setLosses(double losses) {
+		this.losses = losses / 100;
+	}
+
+	public double getMaxTransportCapacity() {
+		return maxTransportCapacity;
+	}
+
+	public void setMaxTransportCapacity(double maxTransportCapacity) {
+		this.maxTransportCapacity = maxTransportCapacity;
+	}
+
+//	/**
+//	 * Updates the line between nodeA and nodeB.
+//	 */
+//	public void updateLine() {
+//		setLn();
+//	}
+//
+//	/**
+//	 * Creates a line between the position of nodeA and the position of nodeB and
+//	 * sets {@link Connection#ln} to it. The instance of {@link PositionManager}
+//	 * must be retrieved within the method in order to allow for correct
+//	 * deserialization
+//	 */
+//	public void setLn() {
+//		ln = new Line2D.Float(nodeA.getPosition(), nodeB.getPosition());
+//	}
+
+	public String getNameNodeA() {
+		return nameNodeA;
+	}
+
+	public void setNameNodeA(String nameNodeA) {
+		this.nameNodeA = nameNodeA;
+	}
+
+	public String getFormattedNameNodeA() {
+		return formattedNameNodeA;
+	}
+
+	public void setFormattedNameNodeA(String NameNodeA) {
+		this.formattedNameNodeA = formatName(NameNodeA);
+	}
+
+	public String getNameNodeB() {
+		return nameNodeB;
+	}
+
+	public void setNameNodeB(String nameNodeB) {
+		this.nameNodeB = nameNodeB;
+	}
+
+	public String getFormattedNameNodeB() {
+		return formattedNameNodeB;
+	}
+
+	public void setFormattedNameNodeB(String NameNodeB) {
+		this.formattedNameNodeB = formatName(NameNodeB);
+	}
+
+	public String formatName(String name) {
+		String formattedName = name.replace("Ä", "Ae").replace("Ö", "Oe").replace("Ü", "Ue").replace("ä", "ae")
+				.replace("ö", "oe").replace("ü", "ue").replace("ß", "ss");
+		return formattedName;
+	}
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/CouplerJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/CouplerJsonHelper.java
@@ -1,0 +1,133 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.CouplerMessage;
+
+/**
+ * Coupler is the class for representing Coupler objects. Example: CHP, HeatPump
+ */
+public class CouplerJsonHelper{
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkTypeP; // Primary, Values: Heat or Electricity
+	@Expose
+	private String networkTypeS; // Secondary, Values: Heat or Electricity
+	@Expose
+	private double minimumPower;
+	@Expose
+	private double maximumPower;
+	@Expose
+	private double efficiencyPrimary;
+	@Expose
+	private double efficiencySecondary;
+	@Expose
+	private double cost;
+	@Expose
+	private double coEmission;
+
+	/**
+	 * Constructor for class Coupler
+	 * 
+	 * @param name                an alphanumeric string
+	 * @param networkTypeP        primary network type. A string: Heat or
+	 *                            Electricity
+	 * @param networkTypeS        secondary network type. A string: Heat or
+	 *                            Electricity
+	 * @param minimumPower        a positive double [kW]
+	 * @param maximumPower        a positive double [kW]
+	 * @param efficiencyPrimary   primary network efficiency. A positive double
+	 * @param efficiencySecondary secondary network efficiency. A negative double
+	 * @param cost                cost [EUR]
+	 * @param coEmission          CO2 Emissions measured in [g/kWh]
+	 */
+	public CouplerJsonHelper(CouplerMessage couplerMessage) {
+
+		setName(couplerMessage.name);
+		setNetworkTypeP(couplerMessage.primaryNetwork);
+		setNetworkTypeS(couplerMessage.secondaryNetwork);
+		setMinimumPower(couplerMessage.minPower);
+		setMaximumPower(couplerMessage.maxPower);
+		// TODO: Problem! Primary/Secondary Efficiency in Coupler Message!
+		setEfficiencyPrimary(couplerMessage.efficiencyHeat);
+		setEfficiencySecondary(couplerMessage.efficiencyElec);
+		setCost(couplerMessage.operationalCostEUR);
+		setCOEmission(couplerMessage.operationalCostCO2);
+
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getNetworkTypeP() {
+		return networkTypeP;
+	}
+
+	public void setNetworkTypeP(NetworkType networkTypeP) {
+		this.networkTypeP = networkTypeP.toString();
+	}
+
+	public String getNetworkTypeS() {
+		return networkTypeS;
+	}
+
+	public void setNetworkTypeS(NetworkType networkTypeS) {
+		this.networkTypeS = networkTypeS.toString();
+	}
+
+	public double getMinimumPower() {
+		return minimumPower;
+	}
+
+	public void setMinimumPower(double minimumPower) {
+		this.minimumPower = minimumPower;
+	}
+
+	public double getMaximumPower() {
+		return maximumPower;
+	}
+
+	public void setMaximumPower(double maximumPower) {
+		this.maximumPower = maximumPower;
+	}
+
+	public double getEfficiencyPrimary() {
+		return efficiencyPrimary;
+	}
+
+	public void setEfficiencyPrimary(double efficiencyNetworkP) {
+		this.efficiencyPrimary = efficiencyNetworkP;
+	}
+
+	public double getEfficiencySecondary() {
+		return efficiencySecondary;
+	}
+
+	public void setEfficiencySecondary(double efficiencyNetworkS) {
+		this.efficiencySecondary = efficiencyNetworkS;
+	}
+
+	public double getCost() {
+		return cost;
+	}
+
+	public void setCost(double cost) {
+		this.cost = cost;
+	}
+
+	public double getCOEmission() {
+		return coEmission;
+	}
+
+	public void setCOEmission(double coEmission) {
+		this.coEmission = coEmission;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/DemandJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/DemandJsonHelper.java
@@ -1,0 +1,45 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.planning.DemandMessage;
+
+/**
+ * Demand is the class for representing Consumers.
+ */
+public class DemandJsonHelper {
+
+	@Expose
+	private String consumptionProfile;
+	@Expose
+	private String name;
+
+	/**
+	 * Constructor for class Demand
+	 * 
+	 * @param name               an alphanumeric string
+	 * @param index              an positive integer
+	 * @param consumptionProfile a path to an existing file
+	 * @param networkType        a string: Heat or Electricity
+	 */
+	public DemandJsonHelper(DemandMessage demandMessage) {
+		setName(demandMessage.name);
+		setConsumptionProfile("");
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+	public String getConsumptionProfile() {
+		return consumptionProfile;
+	}
+
+	public void setConsumptionProfile(String consumptionFile) {
+		this.consumptionProfile = consumptionFile;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/JsonExportHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/JsonExportHelper.java
@@ -1,0 +1,82 @@
+package memap.helper.JsonExportHelper;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import akka.basicMessages.AnswerContent;
+import akka.basicMessages.BasicAnswer;
+import memap.controller.TopologyController;
+import memap.helper.EnergyPrices;
+import memap.helperOPCua.OpcServerContextGenerator;
+import memap.main.Simulation;
+import memap.main.TopologyConfig;
+import memap.messages.BuildingMessage;
+import memap.messages.planning.CouplerMessage;
+import memap.messages.planning.DemandMessage;
+import memap.messages.planning.ProducerMessage;
+import memap.messages.planning.StorageMessage;
+
+public class JsonExportHelper {
+
+	public static void exportMemapTopology(TopologyController topologyController, ArrayList<BasicAnswer> answerListReceived) {
+		ArrayList<Object> list = new ArrayList<Object>();
+		Set<BuildingJsonHelper> buildingSet = new HashSet<BuildingJsonHelper>();
+		BuildingJsonHelper bjh = null;
+		
+		for (BasicAnswer basicAnswer : answerListReceived) {
+			AnswerContent answerContent = basicAnswer.answerContent;
+			if (answerContent instanceof BuildingMessage) {
+				BuildingMessage bmsg = (BuildingMessage) answerContent;
+									
+				bjh = new BuildingJsonHelper(bmsg);
+				
+				for (DemandMessage dm : bmsg.demandList) {
+					DemandJsonHelper djh = new DemandJsonHelper(dm);
+					bjh.addDemand(djh);
+				}
+				for (CouplerMessage cm : bmsg.couplerList) {
+					CouplerJsonHelper cjh = new CouplerJsonHelper(cm);
+					bjh.addCoupler(cjh);
+				}
+				for (ProducerMessage pm : bmsg.controllableProducerList) {
+					ProducerJsonHelper pjh = new ProducerJsonHelper(pm);
+					bjh.addContProduction(pjh);
+				}
+				for (ProducerMessage vpm : bmsg.volatileProducerList) {
+					VolatileJsonHelper vjh = new VolatileJsonHelper(vpm);
+					bjh.addVolProduction(vjh);
+				}
+				for (StorageMessage sm : bmsg.storageList) {
+					StorageJsonHelper sjh = new StorageJsonHelper(sm);
+					bjh.addStorage(sjh);
+				}
+			}
+		buildingSet.add(bjh);
+		}
+		list.add(buildingSet);
+		
+		Set<Object> connections = new HashSet<Object>();
+		list.add(connections);
+		
+		Set<ParameterJsonHelper> parameterSet = new HashSet<ParameterJsonHelper>();
+		ParameterJsonHelper paramjh = new ParameterJsonHelper(
+				TopologyConfig.getInstance().getTimeStepsPerDay(),
+				Simulation.N_STEPS_MPC,
+				TopologyConfig.getInstance().getNrDays(),
+				topologyController.getOptimizationCriteria().toString(),
+				topologyController.getOptimizer().toString(),
+				topologyController.getLogging().toString(),
+				new PriceJsonHelper(true, EnergyPrices.getInstance().getElecBuyingPrice(0), "", Simulation.N_STEPS_MPC),   // elecBuyingPrice
+				new PriceJsonHelper(true, EnergyPrices.getInstance().getElecSellingPrice(0), "", Simulation.N_STEPS_MPC),  // elecSellingPrice
+				new PriceJsonHelper(true, EnergyPrices.getInstance().getHeatBuyingPrice(0), "", Simulation.N_STEPS_MPC),  // heatBuyingPrice
+				new PriceJsonHelper(true, 0.404, "", Simulation.N_STEPS_MPC)  // co2Emissions
+				);
+		parameterSet.add(paramjh);
+		list.add(parameterSet);
+
+		OpcServerContextGenerator.generateJson("ExportForPlanningTool", list);
+	}
+	
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/JsonExportHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/JsonExportHelper.java
@@ -12,6 +12,7 @@ import memap.helperOPCua.OpcServerContextGenerator;
 import memap.main.Simulation;
 import memap.main.TopologyConfig;
 import memap.messages.BuildingMessage;
+import memap.messages.planning.ConnectionMessage;
 import memap.messages.planning.CouplerMessage;
 import memap.messages.planning.DemandMessage;
 import memap.messages.planning.ProducerMessage;
@@ -21,7 +22,10 @@ public class JsonExportHelper {
 
 	public static void exportMemapTopology(TopologyController topologyController, ArrayList<BasicAnswer> answerListReceived) {
 		ArrayList<Object> list = new ArrayList<Object>();
+		
 		Set<BuildingJsonHelper> buildingSet = new HashSet<BuildingJsonHelper>();
+		Set<ConnectionJsonHelper> connections = new HashSet<ConnectionJsonHelper>();
+		
 		BuildingJsonHelper bjh = null;
 		
 		for (BasicAnswer basicAnswer : answerListReceived) {
@@ -51,13 +55,14 @@ public class JsonExportHelper {
 					StorageJsonHelper sjh = new StorageJsonHelper(sm);
 					bjh.addStorage(sjh);
 				}
+				
+				for (ConnectionMessage cm : bmsg.connectionList) {
+					ConnectionJsonHelper connjh = new ConnectionJsonHelper(cm);
+					connections.add(connjh);
+				}
 			}
 		buildingSet.add(bjh);
 		}
-		list.add(buildingSet);
-		
-		Set<Object> connections = new HashSet<Object>();
-		list.add(connections);
 		
 		Set<ParameterJsonHelper> parameterSet = new HashSet<ParameterJsonHelper>();
 		ParameterJsonHelper paramjh = new ParameterJsonHelper(
@@ -73,8 +78,11 @@ public class JsonExportHelper {
 				new PriceJsonHelper(true, 0.404, "", Simulation.N_STEPS_MPC)  // co2Emissions
 				);
 		parameterSet.add(paramjh);
+		
+		list.add(buildingSet);
+		list.add(connections);
 		list.add(parameterSet);
-
+		
 		OpcServerContextGenerator.generateJson("ExportForPlanningTool", list);
 	}
 	

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
@@ -1,0 +1,154 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * Stores the parameter configuration selected by the user and the default
+ * values.
+ */
+public class ParameterJsonHelper {
+
+	/** Simulation name */
+	private String simulationName;
+	/** length MemapSimulation steps. An integer */
+	@Expose
+	private int stepsPerDay;
+	/** steps MPC horizon. An integer */
+	@Expose
+	private int mpcHorizon;
+	/** days Number of days to be simulated */
+	@Expose
+	private int days;
+	/** optCriteria a String. Optimization criteria: {cost, co2} */
+	@Expose
+	private String optCriteria;
+	/** optimizer a String. Optimizer: {LP, MILP} */
+	@Expose
+	private String optimizer;
+	/** loggingMode a String. loggingMode: {allLogs, fileLogs, resultLogs} */
+	@Expose
+	private String loggingMode;
+	@Expose
+	private PriceJsonHelper elecSellingPrice;
+	@Expose
+	private PriceJsonHelper elecBuyingPrice;
+	@Expose
+	private PriceJsonHelper heatBuyingPrice;
+	@Expose
+	private PriceJsonHelper co2Emissions;
+
+	/**
+	 * Constructor for class Parameters
+	 */
+	public ParameterJsonHelper(int simulationSteps, int mpcHorizon, int days, String optCriteria,
+			String optimizer, String loggingMode, PriceJsonHelper elecBuyingPrice, PriceJsonHelper elecSellingPrice,
+			PriceJsonHelper heatBuyingPrice, PriceJsonHelper co2Emissions) {
+		setSimulationName("ImportFromMEMAPServer");
+		setStepsPerDay(simulationSteps);
+		this.mpcHorizon = mpcHorizon;
+		setDays(days);
+		setOptimizer(optimizer);
+		setOptCriteria(optCriteria);
+		setLoggingMode(loggingMode);
+		setElecBuyingPrice(elecBuyingPrice);
+		setElecSellingPrice(elecSellingPrice);
+		setHeatBuyingPrice(heatBuyingPrice);
+		setCO2Emissions(co2Emissions);
+	}
+
+	public String getSimulationName() {
+		return simulationName;
+	}
+
+	/**
+	 * Must be manually set after deserialization!
+	 */
+	public void setSimulationName(String simulationName) {
+		this.simulationName = simulationName;
+	}
+
+	public int getStepsPerDay() {
+		return stepsPerDay;
+	}
+
+	public void setStepsPerDay(int stepsPerDay) {
+		this.stepsPerDay = stepsPerDay;
+	}
+
+	public int getMPCHorizon() {
+		return mpcHorizon;
+	}
+
+//	public void setMPCHorizon(int mpcHorizon) {
+//		this.mpcHorizon = mpcHorizon;
+//		elecBuyingPrice.updateMPCHorizon(mpcHorizon);
+//		elecSellingPrice.updateMPCHorizon(mpcHorizon);
+//		heatBuyingPrice.updateMPCHorizon(mpcHorizon);
+//		setSaved(false);
+//	}
+
+	public int getDays() {
+		return days;
+	}
+
+	public void setDays(int days) {
+		this.days = days;
+	}
+
+	public String getOptimizer() {
+		return optimizer;
+	}
+
+	private void setOptimizer(String optimizer) {
+		this.optimizer = optimizer;
+	}
+
+	public String getOptCriteria() {
+		return optCriteria;
+	}
+
+	private void setOptCriteria(String optCriteria) {
+		this.optCriteria = optCriteria;
+	}
+
+	public String getLoggingMode() {
+		return loggingMode;
+	}
+
+	private void setLoggingMode(String loggingMode) {
+		this.loggingMode = loggingMode;
+	}
+
+	public PriceJsonHelper getElecSellingPrice() {
+		return elecSellingPrice;
+	}
+
+	public void setElecSellingPrice(PriceJsonHelper elecSellingPrice) {
+		this.elecSellingPrice = elecSellingPrice;
+	}
+
+	public PriceJsonHelper getElecBuyingPrice() {
+		return elecBuyingPrice;
+	}
+
+	public void setElecBuyingPrice(PriceJsonHelper elecBuyingPrice) {
+		this.elecBuyingPrice = elecBuyingPrice;
+	}
+
+	public PriceJsonHelper getHeatBuyingPrice() {
+		return heatBuyingPrice;
+	}
+
+	public void setHeatBuyingPrice(PriceJsonHelper heatBuyingPrice) {
+		this.heatBuyingPrice = heatBuyingPrice;
+	}
+	
+	public void setCO2Emissions(PriceJsonHelper co2Emissions) {
+		this.co2Emissions = co2Emissions;
+	}
+	
+	public PriceJsonHelper getCO2Emissions() {
+		return co2Emissions;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ParameterJsonHelper.java
@@ -37,9 +37,7 @@ public class ParameterJsonHelper {
 	@Expose
 	private PriceJsonHelper co2Emissions;
 
-	/**
-	 * Constructor for class Parameters
-	 */
+	
 	public ParameterJsonHelper(int simulationSteps, int mpcHorizon, int days, String optCriteria,
 			String optimizer, String loggingMode, PriceJsonHelper elecBuyingPrice, PriceJsonHelper elecSellingPrice,
 			PriceJsonHelper heatBuyingPrice, PriceJsonHelper co2Emissions) {
@@ -60,9 +58,6 @@ public class ParameterJsonHelper {
 		return simulationName;
 	}
 
-	/**
-	 * Must be manually set after deserialization!
-	 */
 	public void setSimulationName(String simulationName) {
 		this.simulationName = simulationName;
 	}
@@ -79,13 +74,9 @@ public class ParameterJsonHelper {
 		return mpcHorizon;
 	}
 
-//	public void setMPCHorizon(int mpcHorizon) {
-//		this.mpcHorizon = mpcHorizon;
-//		elecBuyingPrice.updateMPCHorizon(mpcHorizon);
-//		elecSellingPrice.updateMPCHorizon(mpcHorizon);
-//		heatBuyingPrice.updateMPCHorizon(mpcHorizon);
-//		setSaved(false);
-//	}
+	public void setMPCHorizon(int mpcHorizon) {
+		this.mpcHorizon = mpcHorizon;
+	}
 
 	public int getDays() {
 		return days;

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/PriceJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/PriceJsonHelper.java
@@ -1,0 +1,34 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+public class PriceJsonHelper {
+	@Expose
+	private boolean fixed;
+	@Expose
+	private double price;
+	@Expose
+	private String priceFilePath;
+
+	public PriceJsonHelper(boolean fixed, double price, String priceFilePath, int mpcHorizon) {
+		setFixed(fixed);
+		setPrice(price, mpcHorizon);
+		setPriceFilePath(priceFilePath);
+	}
+
+	public boolean isFixed() {
+		return fixed;
+	}
+
+	public void setFixed(boolean fixed) {
+		this.fixed = fixed;
+	}
+	
+	public void setPrice(double price, int mpcHorizon) {
+		this.price = price;
+	}
+
+	public void setPriceFilePath(String priceFilePath) {
+		this.priceFilePath = priceFilePath;
+	}
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ProducerJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/ProducerJsonHelper.java
@@ -1,0 +1,105 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.ProducerMessage;
+
+/**
+ * Controllable is the class for representing controllable Producer objects.
+ * Example: Gas Boiler
+ */
+public class ProducerJsonHelper{
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkType; // Values: Heat or Electricity
+	@Expose
+	private double minimumPower;
+	@Expose
+	private double maximumPower;
+	@Expose
+	private double efficiency;
+	@Expose
+	private double cost;
+	@Expose
+	private double coEmission;
+
+	/**
+	 * Constructor for class Controllable
+	 * 
+	 * @param name        an alphanumeric string
+	 * @param networkType a string: Heat or Electricity
+	 * @param minimumPower        a positive double [kW]
+	 * @param maximumPower        a positive double [kW]
+	 * @param efficiency  a positive double
+	 * @param cost        a positive double [EUR]
+	 * @param coEmission  CO2 Emissions measured in [g/kWh]
+	 */
+	public ProducerJsonHelper(ProducerMessage producerMessage) {
+		
+		setName(producerMessage.name);
+		setNetworkType(producerMessage.networkType);
+		setMinimumPower(producerMessage.minPower);
+		setMaximumPower(producerMessage.maxPower);
+		setEfficiency(producerMessage.efficiency);
+		setCost(producerMessage.operationalCostEUR);
+		setCOEmission(producerMessage.operationalCostCO2);
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getNetworkType() {
+		return networkType;
+	}
+
+	public void setNetworkType(NetworkType networkType) {
+		this.networkType = networkType.toString();
+	}
+
+	public double getMinimumPower() {
+		return minimumPower;
+	}
+
+	public void setMinimumPower(double minimumPower) {
+		this.minimumPower = minimumPower;
+	}
+	
+	public double getMaximumPower() {
+		return maximumPower;
+	}
+
+	public void setMaximumPower(double maximumPower) {
+		this.maximumPower = maximumPower;
+	}
+
+	public double getEfficiency() {
+		return efficiency;
+	}
+
+	public void setEfficiency(double efficiency) {
+		this.efficiency = efficiency;
+	}
+
+	public double getCost() {
+		return cost;
+	}
+
+	public void setCost(double cost) {
+		this.cost = cost;
+	}
+
+	public double getCOEmission() {
+		return coEmission;
+	}
+
+	public void setCOEmission(double coEmission) {
+		this.coEmission = coEmission;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/StorageJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/StorageJsonHelper.java
@@ -1,0 +1,130 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.StorageMessage;
+
+/**
+ * Storage is the class for representing Storage objects. Example: Battery,
+ * ThermalStorage.
+ */
+public class StorageJsonHelper {
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkType;
+	@Expose
+	private double capacity;
+	@Expose
+	private double soc;
+	@Expose
+	private double losses;
+	@Expose
+	private double maxCharging;
+	@Expose
+	private double maxDischarging;
+	@Expose
+	private double effIN;
+	@Expose
+	private double effOUT;
+
+	/**
+	 * Constructor for class Storage
+	 * 
+	 * @param name           an alphanumeric string
+	 * @param networkType    a string: Heat or Electricity
+	 * @param capacity       a positive double
+	 * @param soc            state of charge
+	 * @param losses         losses [%/h]. Percentage is in [0, 1]
+	 * @param maxCharging    maximum charging rate. A positive double
+	 * @param maxDischarging maximum discharging rate. A positive double
+	 * @param effIN          charging efficiency. A positive double
+	 * @param effOUT         discharging efficiency. A positive double
+	 */
+	public StorageJsonHelper(StorageMessage storageMessage) {
+		setName(storageMessage.name);
+		setNetworkType(storageMessage.networkType);
+		setCapacity(storageMessage.capacity);
+		setSoc(storageMessage.stateOfCharge);
+		setLosses(storageMessage.storageLosses);
+		setMaxCharging(storageMessage.maxLoad);
+		setMaxDischarging(storageMessage.maxDischarge);
+		setEffIN(storageMessage.efficiencyCharge);
+		setEffOUT(storageMessage.efficiencyDischarge);
+	}
+	
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getNetworkType() {
+		return networkType;
+	}
+
+	public void setNetworkType(NetworkType networkType) {
+		this.networkType = networkType.toString();
+	}
+
+	public double getCapacity() {
+		return capacity;
+	}
+
+	public void setCapacity(double capacity) {
+		this.capacity = capacity;
+	}
+
+	public double getSoc() {
+		return soc;
+	}
+
+	public void setSoc(double soc) {
+		this.soc = soc;
+	}
+
+	public double getLosses() {
+		return losses;
+	}
+
+	public void setLosses(double losses) {
+		// TODO, we might add units for losses in future. We should assure that it is written here correctly.
+		this.losses = losses;
+	}
+
+	public double getMaxCharging() {
+		return maxCharging;
+	}
+
+	public void setMaxCharging(double maxCharging) {
+		this.maxCharging = maxCharging;
+	}
+
+	public double getMaxDischarging() {
+		return maxDischarging;
+	}
+
+	public void setMaxDischarging(double maxDischargeRate) {
+		this.maxDischarging = maxDischargeRate;
+	}
+
+	public double getEffIN() {
+		return effIN;
+	}
+
+	public void setEffIN(double efficiencyCharge) {
+		this.effIN = efficiencyCharge;
+	}
+
+	public double getEffOUT() {
+		return effOUT;
+	}
+
+	public void setEffOUT(double efficiencyDischarge) {
+		this.effOUT = efficiencyDischarge;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/VolatileJsonHelper.java
+++ b/projects/memapCore/src/main/java/memap/helper/JsonExportHelper/VolatileJsonHelper.java
@@ -1,0 +1,105 @@
+package memap.helper.JsonExportHelper;
+
+import com.google.gson.annotations.Expose;
+
+import memap.messages.extension.NetworkType;
+import memap.messages.planning.ProducerMessage;
+
+/**
+ * Volatile is the class for representing volatile Producer objects. Example:
+ * PV, SolarThermic
+ */
+public class VolatileJsonHelper {
+
+	@Expose
+	private String name;
+	@Expose
+	private String networkType; // Values: Heat or Electricity
+	@Expose
+	private double minimumPower;
+	@Expose
+	private double maximumPower;
+	@Expose
+	private String forecastFile;
+	@Expose
+	private double cost;
+	@Expose
+	private double coEmission;
+
+
+	/**
+	 * Constructor for class Volatile
+	 * 
+	 * @param name         an alphanumeric string
+	 * @param networkType  a string: Heat or Electricity
+	 * @param minimumPower a positive double [kW]
+	 * @param maximumPower a positive double [kW]
+	 * @param forecastFile a path to an existing file
+	 * @param cost         a positive double [EUR]
+	 * @param coEmission   CO2 Emissions measured in [g/kWh]
+	 */
+	public VolatileJsonHelper(ProducerMessage producerMessage) {
+
+		setName(producerMessage.name);
+		setNetworkType(producerMessage.networkType);
+		setMinimumPower(producerMessage.minPower);
+		setMaximumPower(producerMessage.maxPower);
+		setCost(producerMessage.operationalCostEUR);
+		setCOEmission(producerMessage.operationalCostCO2);
+		}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getNetworkType() {
+		return networkType;
+	}
+
+	public void setNetworkType(NetworkType networkType) {
+		this.networkType = networkType.toString();
+	}
+
+	public double getMinimumPower() {
+		return minimumPower;
+	}
+
+	public void setMinimumPower(double minimumPower) {
+		this.minimumPower = minimumPower;
+	}
+
+	public double getMaximumPower() {
+		return maximumPower;
+	}
+
+	public void setMaximumPower(double maximumPower) {
+		this.maximumPower = maximumPower;
+	}
+
+	public String getForecastFile() {
+		return forecastFile;
+	}
+
+	public void setForecastFile(String forecastFile) {
+		this.forecastFile = forecastFile;
+	}
+
+	public double getCost() {
+		return cost;
+	}
+
+	public void setCost(double cost) {
+		this.cost = cost;
+	}
+
+	public double getCOEmission() {
+		return coEmission;
+	}
+
+	public void setCOEmission(double coEmission) {
+		this.coEmission = coEmission;
+	}
+
+}

--- a/projects/memapCore/src/main/java/memap/helperOPCua/OpcServerContextGenerator.java
+++ b/projects/memapCore/src/main/java/memap/helperOPCua/OpcServerContextGenerator.java
@@ -4,10 +4,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-
+import java.util.ArrayList;
 import com.google.gson.Gson;
 
-import akka.basicMessages.AnswerContent;
 import helper.IoHelper;
 import memap.helper.DirectoryConfiguration;
 
@@ -15,11 +14,12 @@ public class OpcServerContextGenerator {
 
 	public static Gson gson = new Gson();
 
-	public static void generateJson(String actorName, AnswerContent content) {
-		String result = gson.toJson(content);
+	public static void generateJson(String actorName, ArrayList<Object> list) {
+		String result = gson.toJson(list);
 		writeFile(actorName, result);
 	}
 
+	
 	// TODO adapt the output folder
 	private static void writeFile(String filename, String result) {
 		String source = "/" + DirectoryConfiguration.mainDir + "/" + DirectoryConfiguration.configDir + "/" + filename

--- a/projects/memapCore/src/main/java/memap/main/JettyStart.java
+++ b/projects/memapCore/src/main/java/memap/main/JettyStart.java
@@ -72,13 +72,23 @@ public class JettyStart {
 
 	public void run(JsonObject memapStartMessage) {
 
-		topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILPwithConnections,
-				OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.ALL);
+		topologyMemapOn = new TopologyController(
+				"MemapOn", 
+				OptHierarchy.MEMAP, 
+				Optimizer.MILPwithConnections,
+				OptimizationCriteria.EUR, 
+				ToolUsage.SERVER, 
+				MEMAPLogging.ALL
+				);
 
 		TopologyConfig.getInstance().init(Simulation.N_STEPS_MPC, 96, 30, 7020, 0);
 		System.out.println(">> MPC set to " + Simulation.N_STEPS_MPC);
-		EnergyPrices.getInstance().init(new ElectricityPrice(0.285, Simulation.N_STEPS_MPC),
-				new ElectricityPrice(0.285, Simulation.N_STEPS_MPC), new HeatPrice(0.285, Simulation.N_STEPS_MPC));
+		
+		EnergyPrices.getInstance().init(
+				new ElectricityPrice(0.285, Simulation.N_STEPS_MPC), //global buying price
+				new ElectricityPrice(0.08, Simulation.N_STEPS_MPC),  //global selling price
+				new HeatPrice(0.13, Simulation.N_STEPS_MPC) 		 //global heat price
+				);
 
 		if (doubleSim) {
 			topologyMemapOff = new TopologyController("MemapOff", OptHierarchy.BUILDING, Optimizer.MILP,

--- a/projects/memapCore/src/main/java/memap/main/JettyStart.java
+++ b/projects/memapCore/src/main/java/memap/main/JettyStart.java
@@ -66,65 +66,108 @@ public class JettyStart {
 	 * for their status. (Currently 0 = connected, 1 = not connected)
 	 * 
 	 * @param memapStartMessage JsonArray. Contains the buildingName, the OPC-UA
-	 *                          address, the endpointDescriptor, and the nodesConfig
-	 *                          Json file.
+	 *                          address, the endpointDescriptor, the nodesConfig
+	 *                          Json file, and optional the heat-connections.
 	 */
 
 	public void run(JsonObject memapStartMessage) {
 
-		topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILPwithConnections,
-				OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.ALL);
+		// Collect information from memapStartMessage (JSON)
+		
+		int num = 0;
 
-		TopologyConfig.getInstance().init(Simulation.N_STEPS_MPC, 96, 30, 7020, 0);
+		errorCode = new JsonObject();
+		
+		JsonObject project = null;
+		JsonArray endpoints = null;
+		JsonArray connections = null;
+		
+		try {
+			project = (JsonObject) memapStartMessage.get("project");
+			endpoints = (JsonArray) project.get("endpoints");
+		} catch (Exception e1) {
+			System.err.println("JSON Object startMessage has bad format.");
+			e1.printStackTrace();
+		}
+		
+		// TODO: Further distinguish here between MILP/LP optimizer and between EUR/CO2 criteria
+		// ****************************
+		if (project.toJson().contains("connections")){
+			System.out.println(">> Heat connection information availible.");
+			connections = (JsonArray) project.get("connections");
+			
+			topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILPwithConnections,
+				OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.ALL);		
+		} else {
+			System.out.println(">> No heat connection information availible. Assuming unlimited heat exchange.");
+			topologyMemapOn = new TopologyController("MemapOn", OptHierarchy.MEMAP, Optimizer.MILP ,
+					OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.ALL);
+		}
+		// ****************************
+		
+		// MPC input through start of the simulation environment. For MPC as an input parameter, 
+		// probably the global variable Simulation.N_STEPS_MPC has to be changed here.
+		
 		System.out.println(">> MPC set to " + Simulation.N_STEPS_MPC);
+		TopologyConfig.getInstance().init(Simulation.N_STEPS_MPC, 96, 30, 7020, 0);
+		
+		
+		// Global EnergyPrices: Import can be designed similar to connection (see planning tool), 
+		// but is not necessary, if buildings provide price values via OPC UA.
 		EnergyPrices.getInstance().init(new ElectricityPrice(0.285, Simulation.N_STEPS_MPC),
 				new ElectricityPrice(0.285, Simulation.N_STEPS_MPC), new HeatPrice(0.285, Simulation.N_STEPS_MPC));
 
+		// Starts additional simulation threads on the building level if doubleSim = true.
 		if (doubleSim) {
 			topologyMemapOff = new TopologyController("MemapOff", OptHierarchy.BUILDING, Optimizer.MILP,
 					OptimizationCriteria.EUR, ToolUsage.SERVER, MEMAPLogging.ALL);
 		}
 
-		errorCode = new JsonObject();
-
-		int num = 0;
-
-		JsonArray endpoints = null;
-		try {
-			JsonObject project = (JsonObject) memapStartMessage.get("project");
-			endpoints = (JsonArray) project.get("endpoints");
-			num = endpoints.size();
-		} catch (Exception e1) {
-			System.err.println("JSON Object startMessage has bad format.");
-			e1.printStackTrace();
-		}
-
-		setNumofBuildings(num);
-		System.out.println(">> Number of buildings: " + num);
+		
+		
+		setNumofBuildings(endpoints.size());
+		System.out.println(">> Number of buildings: " + endpoints.size());
 
 		for (int i = 0; i < endpoints.size(); i++) {
 
 			JsonObject jsonEndpoint = (JsonObject) endpoints.get(i);
 			JsonObject configNodes = null;
 
+			// Check if a heat connection exists for this building:
+			String endpointName = (String) jsonEndpoint.get("name");
+			String nameNodeA = null;
+			JsonObject thisBuildingConnection = null;
+			
+			for (int j = 0; j < connections.size(); j++) {
+				JsonObject jsonConnection = (JsonObject) connections.get(j);
+				nameNodeA = (String) jsonConnection.get("nameNodeA");		
+				if (nameNodeA.equals(endpointName)) {
+					thisBuildingConnection = jsonConnection;
+					System.out.println(">> Heat connection found for Building " + (i + 1) + ":");
+					System.out.println(thisBuildingConnection.toString());
+				
+				}
+				
+			}
+			
 			try {
 
 				configNodes = (JsonObject) jsonEndpoint.get("config");
 
-				System.out.println("Building " + (i + 1) + " will be added...");
+				System.out.println(">> Building " + (i + 1) + " (" + endpointName + ") will be added...");
 				BuildingController sampleBuilding = new OpcUaBuildingController(topologyMemapOn, jsonEndpoint,
-						configNodes);
+						configNodes, thisBuildingConnection);
 				topologyMemapOn.attach(sampleBuilding.getName(), sampleBuilding);
 				if (doubleSim) {
 					topologyMemapOff.attach(sampleBuilding.getName(), sampleBuilding);
 				}
-				errorCode.put((String) jsonEndpoint.get("name"), 0);
-				System.out.println("Building " + (i + 1) + " was added...");
+				errorCode.put(endpointName, 0);
+				System.out.println(">> Building " + (i + 1) + " (" + endpointName + ") was added...");
 
 			} catch (IllegalStateException e2) {
-				System.err.println("WARNING: Failed to create Client. Building has not been initialised");
+				System.err.println(">> WARNING: Failed to create Client. Building has not been initialised");
 				e2.printStackTrace();
-				errorCode.put((String) jsonEndpoint.get("name"), 1);
+				errorCode.put((String) endpointName, 1);
 			}
 		}
 

--- a/projects/memapCore/src/main/java/memap/messages/planning/ConnectionMessage.java
+++ b/projects/memapCore/src/main/java/memap/messages/planning/ConnectionMessage.java
@@ -11,6 +11,7 @@ public class ConnectionMessage implements AnswerContent {
 	public String connectedBuildingFrom;
 	
 	public double maxPower;	
+	public double losses;
 	public double efficiency;
 	public double pipeLengthInMeter;
 	


### PR DESCRIPTION
Live-Version:
Replaced the hardcoded "heat connection setting" for CoSES by a JSON-based input through the REST API.

The second list entry from the JSON saved by the GUI (the one defining the heat connections), can now be used as input to the memap API (via Holsten web-based user interface) to account for heat connections between buildings. If done so, heat connections are automatically created for optimization in the live mode of the plattform.

Together with #188 this should enable the folowing procedure:

1. Connect multiple opc ua endpoints/buildings, which have the MEMAP-OPC UA Server naming convention, via the Holsten UI
2. Start the simulation (MILP without connections) via the UI, which sends all relevant NodeIDs top MEMAP, so MEMAP can connect to the endpoints itself and optimize
3. MEMAP creates a JSON with the building & device configuration (topology)
4. this JSON can be loaded into the planning tool to draw real heat connections and be saved as JSON again
5. the saved JSON can be used to cosider the drawn heat connections in the live mode (MILP with connections) 

**TODO**: Build a function to the Holsten UI that loads the JSON from the planning tool, takes the second list entry and adds it to the JSON that is send to MEMAP. An working example file, where the key "connections" was added manually, is uploaded below (_has to be renamed to .json to be used_)

[2HOUSES_COSES_wConn_local_NewArray.txt](https://github.com/SES-fortiss/SmartGridCoSimulation/files/6672658/2HOUSES_COSES_wConn_local_NewArray.txt)
