### PR TITLE
correct math of SOCmin integration

### DIFF
--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemNoConnections.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemNoConnections.java
@@ -348,7 +348,7 @@ public class MILPProblemNoConnections extends MILPProblem {
     			problem.addConstraint(rowCHARGE, LpSolve.LE, (1-(SOC_perc * Math.pow(alpha, i+1))));
     			// for the last timestep in the horizon, the discharge limit is set to be 10%
     			if (i == (nStepsMPC-1) && (Double) sm.minimumSOC != null) {
-    				problem.addConstraint(rowDISCHARGE, LpSolve.LE, sm.minimumSOC);
+    				problem.addConstraint(rowDISCHARGE, LpSolve.LE, ((SOC_perc * Math.pow(alpha, i+1)) - sm.minimumSOC));
     			} else {
     				problem.addConstraint(rowDISCHARGE, LpSolve.LE, (SOC_perc * Math.pow(alpha, i+1)));
     			}

--- a/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
+++ b/projects/memapCore/src/main/java/memap/helper/milp/MILPProblemWithConnections.java
@@ -477,7 +477,7 @@ public class MILPProblemWithConnections extends MILPProblem {
 	    			problem.addConstraint(rowCHARGE, LpSolve.LE, (1-(SOC_perc * Math.pow(alpha, i+1))));
 	    			// for the last timestep in the horizon, the discharge limit is set to be 10%
 	    			if (i == (nStepsMPC-1) && (Double) sm.minimumSOC != null) {
-	    				problem.addConstraint(rowDISCHARGE, LpSolve.LE, sm.minimumSOC);
+	    				problem.addConstraint(rowDISCHARGE, LpSolve.LE, ((SOC_perc * Math.pow(alpha, i+1)) - sm.minimumSOC));
 	    			} else {
 	    				problem.addConstraint(rowDISCHARGE, LpSolve.LE, (SOC_perc * Math.pow(alpha, i+1)));
 	    			}


### PR DESCRIPTION
SOC_min <= SOC(i) <= 1
<=> (SOC(i) <= 1) and (-SOC(i) <= -SOC_min)

for us:
SOC(i) = SOC(0)*(alpha**(i+1))+...

So the lower boundary is:
-... <= SOC(0)*(alpha**(i+1))-SOC_min

"SOC(0)*(alpha**(i+1))" was missing on the righ side. I added it.